### PR TITLE
Update to .NET 7 and Npgsql 7.0.1

### DIFF
--- a/src/PgOutput2Json.RabbitMq/PgOutput2Json.RabbitMq.csproj
+++ b/src/PgOutput2Json.RabbitMq/PgOutput2Json.RabbitMq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;</TargetFrameworks>
+    <TargetFrameworks>net7.0;netstandard2.1;</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.1.10</Version>

--- a/src/PgOutput2Json.Redis/PgOutput2Json.Redis.csproj
+++ b/src/PgOutput2Json.Redis/PgOutput2Json.Redis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.1.10</Version>

--- a/src/PgOutput2Json.TestWorker/PgOutput2Json.TestWorker.csproj
+++ b/src/PgOutput2Json.TestWorker/PgOutput2Json.TestWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-PgOutput2Json.TestWorker-77B74CBA-E15D-4AC5-BFAF-3F827BF624A3</UserSecretsId>

--- a/src/PgOutput2Json.Tests/PgOutput2Json.Tests.csproj
+++ b/src/PgOutput2Json.Tests/PgOutput2Json.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/src/PgOutput2Json/PgOutput2Json.csproj
+++ b/src/PgOutput2Json/PgOutput2Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<Version>0.1.10</Version>
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Npgsql" Version="6.0.1" />
+    <PackageReference Include="Npgsql" Version="7.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Starting a PgOutput2Json Task with Npgsql 7 throws the following exception:
```
System.MissingMethodException: 'Method not found: 
'System.Threading.Tasks.Task`1<Npgsql.Replication.PgOutput.PgOutputReplicationSlot> Npgsql.Replication.PgOutputConnectionExtensions.CreatePgOutputReplicationSlot(Npgsql.Replication.LogicalReplicationConnection, System.String, Boolean, System.Nullable`1<Npgsql.Replication.LogicalSlotSnapshotInitMode>, System.Threading.CancellationToken)'.'
```
Updating to .NET 7 & Npgsql 7 fixes it.