### PR TITLE
Implement initial copying of the existing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,5 @@ FodyWeavers.xsd
 
 # Test SQLite database
 /src/PgOutput2Json.TestWorker/test_database.s3db
+/src/PgOutput2Json.TestWorker/test_database.s3db-shm
+/src/PgOutput2Json.TestWorker/test_database.s3db-wal

--- a/docker/postgres/initdb/01-create-test-db.sql
+++ b/docker/postgres/initdb/01-create-test-db.sql
@@ -1,3 +1,5 @@
+CREATE DATABASE pg_output2json;
+
 CREATE DATABASE test_db;
 
 \connect test_db

--- a/src/PgOutput2Json.Kafka/KafkaPublisher.cs
+++ b/src/PgOutput2Json.Kafka/KafkaPublisher.cs
@@ -70,7 +70,7 @@ namespace PgOutput2Json.Kafka
             return ValueTask.CompletedTask;
         }
 
-        public Task<ulong> GetLastPublishedWalSeq(CancellationToken cancellationToken)
+        public Task<ulong?> GetLastPublishedWalSeq(CancellationToken cancellationToken)
         {
             _logger?.LogInformation("Reading last published WAL LSN for {Topic}", _options.Topic);
 
@@ -126,7 +126,7 @@ namespace PgOutput2Json.Kafka
 
             _logger?.LogInformation("Last published WAL LSN for {Topic}: {LastWalSeq}", _options.Topic, lastWalSeq);
 
-            return Task.FromResult(lastWalSeq);
+            return Task.FromResult<ulong?>(lastWalSeq);
         }
 
         private List<PartitionMetadata> GetPartitionMetadata()

--- a/src/PgOutput2Json.Kafka/KafkaPublisher.cs
+++ b/src/PgOutput2Json.Kafka/KafkaPublisher.cs
@@ -10,7 +10,7 @@ using Confluent.Kafka;
 
 namespace PgOutput2Json.Kafka
 {
-    public class KafkaPublisher: IMessagePublisher
+    public class KafkaPublisher: MessagePublisher
     {
         public KafkaPublisher(KafkaPublisherOptions options, int batchSize, ILogger<KafkaPublisher>? logger = null)
         {
@@ -18,7 +18,7 @@ namespace PgOutput2Json.Kafka
             _logger = logger;
         }
 
-        public Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
+        public override Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
         {
             var msgKey = string.IsNullOrEmpty(keyColumnValue) ? _random.Next().ToString() : keyColumnValue;
 
@@ -46,14 +46,14 @@ namespace PgOutput2Json.Kafka
             return Task.CompletedTask;
         }
 
-        public Task ConfirmAsync(CancellationToken token)
+        public override Task ConfirmAsync(CancellationToken token)
         {
             _producer?.Flush(token);
 
             return Task.CompletedTask;
         }
 
-        public virtual ValueTask DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
             if (_producer != null)
             {
@@ -70,7 +70,7 @@ namespace PgOutput2Json.Kafka
             return ValueTask.CompletedTask;
         }
 
-        public Task<ulong?> GetLastPublishedWalSeq(CancellationToken cancellationToken)
+        public override Task<ulong> GetLastPublishedWalSeq(CancellationToken cancellationToken)
         {
             _logger?.LogInformation("Reading last published WAL LSN for {Topic}", _options.Topic);
 
@@ -126,7 +126,7 @@ namespace PgOutput2Json.Kafka
 
             _logger?.LogInformation("Last published WAL LSN for {Topic}: {LastWalSeq}", _options.Topic, lastWalSeq);
 
-            return Task.FromResult<ulong?>(lastWalSeq);
+            return Task.FromResult(lastWalSeq);
         }
 
         private List<PartitionMetadata> GetPartitionMetadata()

--- a/src/PgOutput2Json.RabbitMq/RabbitMqPublisher.cs
+++ b/src/PgOutput2Json.RabbitMq/RabbitMqPublisher.cs
@@ -10,7 +10,7 @@ using RabbitMQ.Client.Events;
 
 namespace PgOutput2Json.RabbitMq
 {
-    public class RabbitMqPublisher: IMessagePublisher
+    public class RabbitMqPublisher: MessagePublisher
     {
         public RabbitMqPublisher(RabbitMqPublisherOptions options, int batchSize, ILogger<RabbitMqPublisher>? logger = null)
         {
@@ -19,7 +19,7 @@ namespace PgOutput2Json.RabbitMq
             _logger = logger;
         }
 
-        public async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
+        public override async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
         {
             var channel = await EnsureConnection(token)
                 .ConfigureAwait(false);
@@ -43,7 +43,7 @@ namespace PgOutput2Json.RabbitMq
             _pendingTasks.Add(task);
         }
 
-        public async Task ConfirmAsync(CancellationToken token)
+        public override async Task ConfirmAsync(CancellationToken token)
         {
             foreach (var pt in _pendingTasks)
             {
@@ -53,12 +53,7 @@ namespace PgOutput2Json.RabbitMq
             _pendingTasks.Clear();
         }
 
-        public Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
-        {
-            return Task.FromResult<ulong?>(null);
-        }
-
-        public virtual async ValueTask DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             _pendingTasks.Clear();
 

--- a/src/PgOutput2Json.RabbitMq/RabbitMqPublisher.cs
+++ b/src/PgOutput2Json.RabbitMq/RabbitMqPublisher.cs
@@ -53,9 +53,9 @@ namespace PgOutput2Json.RabbitMq
             _pendingTasks.Clear();
         }
 
-        public Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
+        public Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
         {
-            return Task.FromResult(0ul);
+            return Task.FromResult<ulong?>(null);
         }
 
         public virtual async ValueTask DisposeAsync()

--- a/src/PgOutput2Json.RabbitMqStreams/RabbitMqStreamsPublisher.cs
+++ b/src/PgOutput2Json.RabbitMqStreams/RabbitMqStreamsPublisher.cs
@@ -9,7 +9,7 @@ using RabbitMQ.Stream.Client.Reliable;
 
 namespace PgOutput2Json.RabbitMqStreams
 {
-    public class RabbitMqStreamsPublisher: IMessagePublisher
+    public class RabbitMqStreamsPublisher: MessagePublisher
     {
         public RabbitMqStreamsPublisher(RabbitMqStreamsPublisherOptions options, int batchSize, ILoggerFactory? loggerFactory = null)
         {
@@ -21,7 +21,7 @@ namespace PgOutput2Json.RabbitMqStreams
             _logger = loggerFactory?.CreateLogger<RabbitMqStreamsPublisher>();
         }
 
-        public async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
+        public async override Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
         {
             var producer = await EnsureProducer();
 
@@ -44,7 +44,7 @@ namespace PgOutput2Json.RabbitMqStreams
             }
         }
 
-        public async Task ConfirmAsync(CancellationToken token)
+        public async override Task ConfirmAsync(CancellationToken token)
         {
             // only PublishAsync can create the source, ConfirmAsync is never called in parallel
             if (_confirmationTaskCompletionSource != null)
@@ -57,7 +57,7 @@ namespace PgOutput2Json.RabbitMqStreams
             }
         }
 
-        public virtual async ValueTask DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             if (_producer != null)
             {
@@ -162,7 +162,7 @@ namespace PgOutput2Json.RabbitMqStreams
             return _producer;
         }
 
-        public async Task<ulong?> GetLastPublishedWalSeq(CancellationToken stoppingToken)
+        public override async Task<ulong> GetLastPublishedWalSeq(CancellationToken stoppingToken)
         {
             _logger?.LogInformation("Reading last published WAL LSN for: {StreamName}", _options.StreamName);
 

--- a/src/PgOutput2Json.RabbitMqStreams/RabbitMqStreamsPublisher.cs
+++ b/src/PgOutput2Json.RabbitMqStreams/RabbitMqStreamsPublisher.cs
@@ -162,7 +162,7 @@ namespace PgOutput2Json.RabbitMqStreams
             return _producer;
         }
 
-        public async Task<ulong> GetLastPublishedWalSeq(CancellationToken stoppingToken)
+        public async Task<ulong?> GetLastPublishedWalSeq(CancellationToken stoppingToken)
         {
             _logger?.LogInformation("Reading last published WAL LSN for: {StreamName}", _options.StreamName);
 

--- a/src/PgOutput2Json.Redis/RedisPublisher.cs
+++ b/src/PgOutput2Json.Redis/RedisPublisher.cs
@@ -8,7 +8,7 @@ using StackExchange.Redis;
 
 namespace PgOutput2Json.Redis
 {
-    public class RedisPublisher : IMessagePublisher
+    public class RedisPublisher : MessagePublisher
     {
         public RedisPublisher(RedisPublisherOptions options, ILogger<RedisPublisher>? logger = null)
         {
@@ -16,7 +16,7 @@ namespace PgOutput2Json.Redis
             _logger = logger;
         }
 
-        public async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
+        public override async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
         {
             _redis ??= await ConnectionMultiplexer.ConnectAsync(_options.Redis)
                 .ConfigureAwait(false);
@@ -60,7 +60,7 @@ namespace PgOutput2Json.Redis
             }
         }
 
-        public async Task ConfirmAsync(CancellationToken token)
+        public override async Task ConfirmAsync(CancellationToken token)
         {
             foreach (var pt in _publishedTasks)
             {
@@ -70,7 +70,7 @@ namespace PgOutput2Json.Redis
             DisposeTasks();
         }
 
-        public async Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
+        public override async Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
         {
             if (_options.PublishMode == PublishMode.Channel) return 0; // cannot do de-duplication with channels
 
@@ -112,7 +112,7 @@ namespace PgOutput2Json.Redis
             _publishedTasks.Clear();
         }
 
-        public virtual async ValueTask DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             DisposeTasks();
 

--- a/src/PgOutput2Json.Redis/RedisPublisher.cs
+++ b/src/PgOutput2Json.Redis/RedisPublisher.cs
@@ -70,7 +70,7 @@ namespace PgOutput2Json.Redis
             DisposeTasks();
         }
 
-        public async Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
+        public async Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
         {
             if (_options.PublishMode == PublishMode.Channel) return 0; // cannot do de-duplication with channels
 

--- a/src/PgOutput2Json.Sqlite/ConfigKey.cs
+++ b/src/PgOutput2Json.Sqlite/ConfigKey.cs
@@ -6,5 +6,7 @@
 
         public const string DataCopyProgress = "DataCopyProgress";
         public const string DataCopyProgressCompleted = "\"completed\"";
+
+        public const string Schema = "Schema";
     }
 }

--- a/src/PgOutput2Json.Sqlite/ConfigKey.cs
+++ b/src/PgOutput2Json.Sqlite/ConfigKey.cs
@@ -3,5 +3,8 @@
     internal class ConfigKey
     {
         public const string WalEnd = "WalEnd";
+
+        public const string DataCopyProgress = "DataCopyProgress";
+        public const string DataCopyProgressCompleted = "\"completed\"";
     }
 }

--- a/src/PgOutput2Json.Sqlite/ConfigKey.cs
+++ b/src/PgOutput2Json.Sqlite/ConfigKey.cs
@@ -3,10 +3,6 @@
     internal class ConfigKey
     {
         public const string WalEnd = "WalEnd";
-
-        public const string DataCopyProgress = "DataCopyProgress";
-        public const string DataCopyProgressCompleted = "\"completed\"";
-
         public const string Schema = "Schema";
     }
 }

--- a/src/PgOutput2Json.Sqlite/SqliteConnectionExtensions.cs
+++ b/src/PgOutput2Json.Sqlite/SqliteConnectionExtensions.cs
@@ -320,7 +320,7 @@ CREATE TABLE IF NOT EXISTS __pg2j_config (
     {
         public string Name { get; set; }
         public bool IsKey { get; set; }
-        public int DataType { get; set; }
+        public uint DataType { get; set; }
         public int TypeModifier { get; set; }
 
         public readonly string GetSqliteType()

--- a/src/PgOutput2Json.Sqlite/SqliteConnectionExtensions.cs
+++ b/src/PgOutput2Json.Sqlite/SqliteConnectionExtensions.cs
@@ -25,6 +25,26 @@ namespace PgOutput2Json.Sqlite
             await SaveConfig(cn, ConfigKey.WalEnd, walEnd.ToString(CultureInfo.InvariantCulture), token).ConfigureAwait(false);
         }
 
+        public static async Task<string?> GetDataCopyProgress(this SqliteConnection cn, string tableName, CancellationToken token)
+        {
+            return await GetConfig(cn, $"{ConfigKey.DataCopyProgress}_{tableName}", token).ConfigureAwait(false);
+        }
+
+        public static async Task SetDataCopyProgress(this SqliteConnection cn, string tableName, string lastJson, CancellationToken token)
+        {
+            await SaveConfig(cn, $"{ConfigKey.DataCopyProgress}_{tableName}", lastJson, token).ConfigureAwait(false);
+        }
+
+        public static async Task SetDataCopyCompleted(this SqliteConnection cn, string tableName, CancellationToken token)
+        {
+            await SaveConfig(cn, $"{ConfigKey.DataCopyProgress}_{tableName}", ConfigKey.DataCopyProgressCompleted, token).ConfigureAwait(false);
+        }
+
+        public static bool IsDataCopyCompleted(this string? cfgValue)
+        {
+            return cfgValue != null && cfgValue == ConfigKey.DataCopyProgressCompleted;
+        }
+
         public static async Task SaveConfig(this SqliteConnection cn, string key, string value, CancellationToken token)
         {
             using var cmd = cn.CreateCommand();

--- a/src/PgOutput2Json.Sqlite/SqliteConnectionExtensions.cs
+++ b/src/PgOutput2Json.Sqlite/SqliteConnectionExtensions.cs
@@ -26,26 +26,6 @@ namespace PgOutput2Json.Sqlite
             await SaveConfig(cn, ConfigKey.WalEnd, walEnd.ToString(CultureInfo.InvariantCulture), token).ConfigureAwait(false);
         }
 
-        public static async Task<string?> GetDataCopyProgress(this SqliteConnection cn, string tableName, CancellationToken token)
-        {
-            return await GetConfig(cn, $"{ConfigKey.DataCopyProgress}_{tableName}", token).ConfigureAwait(false);
-        }
-
-        public static async Task SetDataCopyProgress(this SqliteConnection cn, string tableName, string lastJson, CancellationToken token)
-        {
-            await SaveConfig(cn, $"{ConfigKey.DataCopyProgress}_{tableName}", lastJson, token).ConfigureAwait(false);
-        }
-
-        public static async Task SetDataCopyCompleted(this SqliteConnection cn, string tableName, CancellationToken token)
-        {
-            await SaveConfig(cn, $"{ConfigKey.DataCopyProgress}_{tableName}", ConfigKey.DataCopyProgressCompleted, token).ConfigureAwait(false);
-        }
-
-        public static bool IsDataCopyCompleted(this string? cfgValue)
-        {
-            return cfgValue != null && cfgValue == ConfigKey.DataCopyProgressCompleted;
-        }
-
         public static async Task SetSchema(this SqliteConnection cn, string tableName, IReadOnlyList<ColumnInfo> cols, CancellationToken token)
         {
             await SaveConfig(cn, $"{ConfigKey.Schema}_{tableName}", JsonSerializer.Serialize(cols), token).ConfigureAwait(false);

--- a/src/PgOutput2Json.Sqlite/SqliteExceptionExtensions.cs
+++ b/src/PgOutput2Json.Sqlite/SqliteExceptionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Data.Sqlite;
+
+namespace PgOutput2Json.Sqlite
+{
+    internal static class SqliteExceptionExtensions
+    {
+        public static bool IsPrimaryKeyViolation(this SqliteException ex)
+        {
+            return ex.SqliteErrorCode == 19 && ex.SqliteExtendedErrorCode == 1555;
+        }
+    }
+}

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -76,10 +76,12 @@ namespace PgOutput2Json.Sqlite
 
             var cfgValue = await cn.GetDataCopyProgress(tableName, token).ConfigureAwait(false);
 
-            return new DataCopyStatus
+            if (cfgValue.IsDataCopyCompleted())
             {
-                IsCompleted = cfgValue.IsDataCopyCompleted(),
-            };
+                return new DataCopyStatus { IsCompleted = true };
+            }
+
+            return new DataCopyStatus { IsCompleted = false, LastJson = cfgValue };
         }
 
         public override async ValueTask DisposeAsync()

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -49,7 +49,7 @@ namespace PgOutput2Json.Sqlite
             _transaction = null;
         }
 
-        public async Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
+        public async Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
         {
             var cn = await EnsureConnection(token).ConfigureAwait(false);
 

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -56,6 +56,32 @@ namespace PgOutput2Json.Sqlite
             return await cn.GetWalEnd(token).ConfigureAwait(false);
         }
 
+        public override async Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token)
+        {
+            var cn = await EnsureConnectionInTransaction(token).ConfigureAwait(false);
+
+            await cn.SetDataCopyProgress(tableName, lastJson, token).ConfigureAwait(false);
+        }
+
+        public override async Task ReportDataCopyCompleted(string tableName, CancellationToken token)
+        {
+            var cn = await EnsureConnectionInTransaction(token).ConfigureAwait(false);
+
+            await cn.SetDataCopyCompleted(tableName, token).ConfigureAwait(false);
+        }
+
+        public override async Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token)
+        {
+            var cn = await EnsureConnection(token).ConfigureAwait(false);
+
+            var cfgValue = await cn.GetDataCopyProgress(tableName, token).ConfigureAwait(false);
+
+            return new DataCopyStatus
+            {
+                IsCompleted = cfgValue.IsDataCopyCompleted(),
+            };
+        }
+
         public override async ValueTask DisposeAsync()
         {
             if (_connection != null)

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -131,13 +131,6 @@ namespace PgOutput2Json.Sqlite
             await connection.CreateOrAlterTable(tableName, columns, token).ConfigureAwait(false);
 
             await connection.SetSchema(tableName, columns, token).ConfigureAwait(false);
-
-            if (walSeq > 0 && _listenerOptions.CopyData)
-            {
-                // if this is a WAL event, and data copy is enabled, it means we can mark it as data copy completed,
-                // because we will receive the rest of the data through replication
-                await connection.SetDataCopyCompleted(tableName, token).ConfigureAwait(false);
-            }
         }
 
         private async Task<SqliteConnection> EnsureConnection(CancellationToken token)

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -10,7 +10,7 @@ using Microsoft.Data.Sqlite;
 
 namespace PgOutput2Json.Sqlite
 {
-    public class SqlitePublisher : IMessagePublisher
+    public class SqlitePublisher : MessagePublisher
     {
         private readonly SqlitePublisherOptions _options;
         private readonly ReplicationListenerOptions _listenerOptions;
@@ -30,7 +30,7 @@ namespace PgOutput2Json.Sqlite
             _logger = logger;
         }
 
-        public async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
+        public override async Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token)
         {
             var connection = await EnsureConnectionInTransaction(token).ConfigureAwait(false);
 
@@ -41,7 +41,7 @@ namespace PgOutput2Json.Sqlite
             await ParseRow(connection, tableName, doc, token).ConfigureAwait(false);
         }
 
-        public async Task ConfirmAsync(CancellationToken token)
+        public override async Task ConfirmAsync(CancellationToken token)
         {
             if (_transaction == null) return;
 
@@ -49,14 +49,14 @@ namespace PgOutput2Json.Sqlite
             _transaction = null;
         }
 
-        public async Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
+        public override async Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
         {
             var cn = await EnsureConnection(token).ConfigureAwait(false);
 
             return await cn.GetWalEnd(token).ConfigureAwait(false);
         }
 
-        public async ValueTask DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             if (_connection != null)
             {

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -82,7 +82,7 @@ namespace PgOutput2Json.Sqlite
             doc.RootElement.TryGetProperty("k", out var keyElement);
             doc.RootElement.TryGetProperty("r", out var rowElement);
 
-            await connection.UpdateOrInsert(walEnd, tableName, columns, changeTypeElement, keyElement, rowElement, token)
+            await connection.UpdateOrInsert(walEnd, tableName, columns, changeTypeElement, keyElement, rowElement, _logger, token)
                 .ConfigureAwait(false);
         }
 

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -13,7 +13,6 @@ namespace PgOutput2Json.Sqlite
     public class SqlitePublisher : MessagePublisher
     {
         private readonly SqlitePublisherOptions _options;
-        private readonly ReplicationListenerOptions _listenerOptions;
         private readonly ILogger<SqlitePublisher>? _logger;
 
         private SqliteConnection? _connection;
@@ -21,12 +20,9 @@ namespace PgOutput2Json.Sqlite
 
         private readonly Dictionary<string, List<ColumnInfo>> _tableColumns = [];
 
-        public SqlitePublisher(SqlitePublisherOptions options,
-                               ReplicationListenerOptions listenerOptions,
-                               ILogger<SqlitePublisher>? logger)
+        public SqlitePublisher(SqlitePublisherOptions options, ILogger<SqlitePublisher>? logger)
         {
             _options = options;
-            _listenerOptions = listenerOptions;
             _logger = logger;
         }
 

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -56,34 +56,6 @@ namespace PgOutput2Json.Sqlite
             return await cn.GetWalEnd(token).ConfigureAwait(false);
         }
 
-        public override async Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token)
-        {
-            var cn = await EnsureConnectionInTransaction(token).ConfigureAwait(false);
-
-            await cn.SetDataCopyProgress(tableName, lastJson, token).ConfigureAwait(false);
-        }
-
-        public override async Task ReportDataCopyCompleted(string tableName, CancellationToken token)
-        {
-            var cn = await EnsureConnectionInTransaction(token).ConfigureAwait(false);
-
-            await cn.SetDataCopyCompleted(tableName, token).ConfigureAwait(false);
-        }
-
-        public override async Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token)
-        {
-            var cn = await EnsureConnection(token).ConfigureAwait(false);
-
-            var cfgValue = await cn.GetDataCopyProgress(tableName, token).ConfigureAwait(false);
-
-            if (cfgValue.IsDataCopyCompleted())
-            {
-                return new DataCopyStatus { IsCompleted = true };
-            }
-
-            return new DataCopyStatus { IsCompleted = false, LastJson = cfgValue };
-        }
-
         public override async ValueTask DisposeAsync()
         {
             if (_connection != null)

--- a/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisher.cs
@@ -105,7 +105,7 @@ namespace PgOutput2Json.Sqlite
                 {
                     var name = colElement[0].GetString() ?? string.Empty;
                     colElement[1].TryGetByte(out var isKey);
-                    colElement[2].TryGetInt32(out var dataType);
+                    colElement[2].TryGetUInt32(out var dataType);
 
                     if (colLength < 4 || !colElement[3].TryGetInt32(out var typeModifier))
                     {

--- a/src/PgOutput2Json.Sqlite/SqlitePublisherFactory.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisherFactory.cs
@@ -13,7 +13,7 @@ namespace PgOutput2Json.Sqlite
 
         public IMessagePublisher CreateMessagePublisher(ReplicationListenerOptions listenerOptions, ILoggerFactory? loggerFactory)
         {
-            return new SqlitePublisher(_options, listenerOptions, loggerFactory?.CreateLogger<SqlitePublisher>());
+            return new SqlitePublisher(_options, loggerFactory?.CreateLogger<SqlitePublisher>());
         }
     }
 }

--- a/src/PgOutput2Json.Sqlite/SqlitePublisherOptions.cs
+++ b/src/PgOutput2Json.Sqlite/SqlitePublisherOptions.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.Data.Sqlite;
+﻿using System;
+using System.Threading.Tasks;
+
+using Microsoft.Data.Sqlite;
 
 namespace PgOutput2Json.Sqlite
 {
     public class SqlitePublisherOptions
     {
         public required SqliteConnectionStringBuilder ConnectionStringBuilder { get; set; }
+        public Func<SqliteConnection, Task>? PostConnectionSetup { get; set; }
     }
 }

--- a/src/PgOutput2Json.TestWorker/Worker.cs
+++ b/src/PgOutput2Json.TestWorker/Worker.cs
@@ -38,6 +38,7 @@ namespace PgOutput2Json.TestWorker
                 .WithPgPublications("test_publication")
                 .WithPgReplicationSlot("test_slot")
                 //.WithPgColumns("public.test_table", "id", "first_name") // optional, use it to filter the columns written to JSON
+                //.CopyData(true) // supported only by Sqlite at the moment (warning be logged if used with other publishers)
                 .WithJsonOptions(options =>
                 {
                     //options.WriteNulls = true;

--- a/src/PgOutput2Json.TestWorker/Worker.cs
+++ b/src/PgOutput2Json.TestWorker/Worker.cs
@@ -40,11 +40,11 @@ namespace PgOutput2Json.TestWorker
                 .WithPgReplicationSlot("test_slot")
                 //.WithBatchSize(10_000) // default is 100
                 //.WithPgColumns("public.test_table", "id", "first_name") // optional, use it to filter the columns written to JSON
-                //.WithInitialDataCopy(true) // supported only by Sqlite at the moment (warning be logged if used with other publishers)
+                //.WithInitialDataCopy(true) // pushes the existing data to the publisher - a separate database named pg_output2json must be created on the source (to track the progress)
                 //.WithDataCopyStatusHandler((tableName, status) =>
                 //{
                 //    // optional, allows implementing logic to continue data copy from a specific point
-                //
+
                 //    if (tableName == "public.test_table")
                 //    {
                 //        status.OrderByColumns = "id";
@@ -53,10 +53,15 @@ namespace PgOutput2Json.TestWorker
                 //        {
                 //            var doc = JsonDocument.Parse(status.LastJson);
 
-                //            // sqlite uses compact write mode, so the rows are arrays, and the first item is the id
-                //            if (doc.RootElement.TryGetProperty("r", out var row) && row.ValueKind == JsonValueKind.Array && row.GetArrayLength() > 0)
+                //            //// use this for compact write mode (sqlite uses is by default)
+                //            //if (doc.RootElement.TryGetProperty("r", out var row) && row.ValueKind == JsonValueKind.Array && row.GetArrayLength() > 0)
+                //            //{
+                //            //    status.AdditionalRowFilter = $"id > {row[0].GetInt32()}";
+                //            //}
+
+                //            if (doc.RootElement.TryGetProperty("r", out var row) && row.TryGetProperty("id", out var id))
                 //            {
-                //                status.AdditionalRowFilter = $"id > {row[0].GetInt32()}";
+                //                status.AdditionalRowFilter = $"id > {id.GetInt32()}";
                 //            }
                 //        }
                 //    }

--- a/src/PgOutput2Json.TestWorker/Worker.cs
+++ b/src/PgOutput2Json.TestWorker/Worker.cs
@@ -38,9 +38,9 @@ namespace PgOutput2Json.TestWorker
                 .WithPgConnectionString("Host=localhost;Database=test_db;Username=postgres;Password=postgres")
                 .WithPgPublications("test_publication")
                 .WithPgReplicationSlot("test_slot")
-                //.WithBatchSize(1000) // default is 100
+                //.WithBatchSize(10_000) // default is 100
                 //.WithPgColumns("public.test_table", "id", "first_name") // optional, use it to filter the columns written to JSON
-                //.CopyData(true) // supported only by Sqlite at the moment (warning be logged if used with other publishers)
+                //.WithInitialDataCopy(true) // supported only by Sqlite at the moment (warning be logged if used with other publishers)
                 //.WithDataCopyStatusHandler((tableName, status) =>
                 //{
                 //    // optional, allows implementing logic to continue data copy from a specific point

--- a/src/PgOutput2Json.TestWorker/Worker.cs
+++ b/src/PgOutput2Json.TestWorker/Worker.cs
@@ -4,6 +4,7 @@ using PgOutput2Json.RabbitMqStreams;
 using PgOutput2Json.Redis;
 using PgOutput2Json.Sqlite;
 using System.Net;
+using System.Text.Json;
 
 namespace PgOutput2Json.TestWorker
 {
@@ -37,8 +38,30 @@ namespace PgOutput2Json.TestWorker
                 .WithPgConnectionString("Host=localhost;Database=test_db;Username=postgres;Password=postgres")
                 .WithPgPublications("test_publication")
                 .WithPgReplicationSlot("test_slot")
+                //.WithBatchSize(1000) // default is 100
                 //.WithPgColumns("public.test_table", "id", "first_name") // optional, use it to filter the columns written to JSON
                 //.CopyData(true) // supported only by Sqlite at the moment (warning be logged if used with other publishers)
+                //.WithDataCopyStatusHandler((tableName, status) =>
+                //{
+                //    // optional, allows implementing logic to continue data copy from a specific point
+                //
+                //    if (tableName == "public.test_table")
+                //    {
+                //        status.OrderByColumns = "id";
+
+                //        if (status.LastJson != null)
+                //        {
+                //            var doc = JsonDocument.Parse(status.LastJson);
+
+                //            // sqlite uses compact write mode, so the rows are arrays, and the first item is the id
+                //            if (doc.RootElement.TryGetProperty("r", out var row) && row.ValueKind == JsonValueKind.Array && row.GetArrayLength() > 0)
+                //            {
+                //                status.AdditionalRowFilter = $"id > {row[0].GetInt32()}";
+                //            }
+                //        }
+                //    }
+
+                //})
                 .WithJsonOptions(options =>
                 {
                     //options.WriteNulls = true;

--- a/src/PgOutput2Json/DataCopyProgress.cs
+++ b/src/PgOutput2Json/DataCopyProgress.cs
@@ -1,0 +1,126 @@
+﻿using Npgsql;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PgOutput2Json
+{
+    internal static class DataCopyProgress
+    {
+        public static async Task<DataCopyStatus> GetDataCopyStatus(string tableName, ReplicationListenerOptions listenerOptions, CancellationToken token)
+        {
+            var (DatabaseName, SlotName, ConnectionString) = GetPgoutput2JsonInfo(listenerOptions);
+
+            if (SlotName == null) return new DataCopyStatus {  IsCompleted = false }; // temporary slot, no use remembering where we left off
+
+            using var cn = new NpgsqlConnection(ConnectionString);
+
+            await cn.OpenAsync(token).ConfigureAwait(false);
+
+            using var cmd = cn.CreateCommand();
+
+            cmd.CommandText = @"
+SELECT is_completed, last_message 
+FROM data_copy_progress 
+WHERE database_name = @database_name
+    AND table_name = @table_name
+    AND slot_name = @slot_name
+";
+            cmd.Parameters.AddWithValue("database_name", DatabaseName);
+            cmd.Parameters.AddWithValue("table_name", tableName);
+            cmd.Parameters.AddWithValue("slot_name", SlotName);
+
+            using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+            var result = new DataCopyStatus();
+
+            if (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                result.IsCompleted = reader.GetBoolean(0);
+                result.LastJson = reader.IsDBNull(1) ? null : reader.GetString(1);
+            }
+
+            await reader.CloseAsync().ConfigureAwait(false);
+
+            return result;
+        }
+
+        public static async Task SetDataCopyProgress(string tableName, ReplicationListenerOptions listenerOptions, bool isCompleted, string? lastJson, CancellationToken token)
+        {
+            var (DatabaseName, SlotName, ConnectionString) = GetPgoutput2JsonInfo(listenerOptions);
+
+            if (SlotName == null) return;
+
+            using var cn = new NpgsqlConnection(ConnectionString);
+
+            await cn.OpenAsync(token).ConfigureAwait(false);
+
+
+            using var cmd = cn.CreateCommand();
+
+            cmd.CommandText = @"
+INSERT INTO data_copy_progress (database_name, table_name, slot_name, is_completed, last_message)
+VALUES (@database_name, @table_name, @slot_name, @is_completed, @last_message)
+ON CONFLICT (database_name, table_name, slot_name)
+DO UPDATE SET
+    is_completed = EXCLUDED.is_completed,
+    last_message = EXCLUDED.last_message
+";
+            cmd.Parameters.AddWithValue("is_completed", isCompleted);
+            cmd.Parameters.AddWithValue("last_message", lastJson ?? (object)DBNull.Value);
+
+            cmd.Parameters.AddWithValue("database_name", DatabaseName);
+            cmd.Parameters.AddWithValue("table_name", tableName);
+            cmd.Parameters.AddWithValue("slot_name", SlotName);
+
+            await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+
+        public static async Task CreateDataCopyProgressTable(ReplicationListenerOptions listenerOptions, CancellationToken token)
+        {
+            var (DatabaseName, SlotName, ConnectionString) = GetPgoutput2JsonInfo(listenerOptions);
+
+            if (SlotName == null) return;
+
+            using var cn = new NpgsqlConnection(ConnectionString);
+
+            await cn.OpenAsync(token).ConfigureAwait(false);
+
+            using var cmd = cn.CreateCommand();
+
+            cmd.CommandText = @"
+CREATE TABLE IF NOT EXISTS data_copy_progress (
+    table_name TEXT NOT NULL,
+    database_name TEXT NOT NULL,
+    slot_name TEXT NOT NULL,
+    is_completed bool NOT NULL DEFAULT false,
+    last_message TEXT,
+    CONSTRAINT pk_data_copy_progress PRIMARY KEY (table_name, database_name, slot_name)
+)";
+
+            await cmd.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+        }
+
+        private static (string DatabaseName, string? SlotName, string ConnectionString) GetPgoutput2JsonInfo(ReplicationListenerOptions listenerOptions)
+        {
+            string? slotName;
+            if (string.IsNullOrWhiteSpace(listenerOptions.ReplicationSlotName) || listenerOptions.UseTemporarySlot)
+            {
+                slotName = null;
+            }
+            else
+            {
+                slotName = listenerOptions.ReplicationSlotName;
+            }
+
+            var cnBuilder = new NpgsqlConnectionStringBuilder(listenerOptions.ConnectionString);
+
+            var databaseName = cnBuilder.Database ?? throw new Exception("Database name not set in connection string");
+
+            cnBuilder.Database = "pg_output2json";
+            var ourConnectionString = cnBuilder.ConnectionString;
+
+            return (databaseName, slotName, ourConnectionString);
+        }
+    }
+}

--- a/src/PgOutput2Json/DataCopyStatus.cs
+++ b/src/PgOutput2Json/DataCopyStatus.cs
@@ -1,0 +1,21 @@
+﻿namespace PgOutput2Json
+{
+    public class DataCopyStatus
+    {
+        public bool IsCompleted { get; set; }
+        public string? LastJson { get; set; }
+
+        /// <summary>
+        /// This is optionally populated by the client app, not used by the publisher.
+        /// It allows the client do decide where to continue the copy process, based on the lastJson exported
+        /// </summary>
+        public string? AdditionalRowFilter { get; set; }
+
+        /// <summary>
+        /// This is optionally populated by the client app, not used by the publisher.
+        /// It is used in compbination with AdditionalRowFilter, and allows the client do decide where to continue the copy process, 
+        /// based on the lastJson exported
+        /// </summary>
+        public string? OrderByColumns { get; set; }
+    }
+}

--- a/src/PgOutput2Json/DataExporter.cs
+++ b/src/PgOutput2Json/DataExporter.cs
@@ -56,9 +56,12 @@ namespace PgOutput2Json
 
                     var dataCopyStatus = await GetDataCopyStatus(publication, listenerOptions, linkedToken).ConfigureAwait(false);
 
-                    logger.SafeLogInfo("Exporting data from Table: {TableName}, RowFilter: {RowFilter}", publication.TableName, publication.RowFilter);
+                    if (!dataCopyStatus.IsCompleted)
+                    {
+                        logger.SafeLogInfo("Exporting data from Table: {TableName}, RowFilter: {RowFilter}", publication.TableName, publication.RowFilter);
 
-                    await ExportData(connection, publisher, writer, listenerOptions, jsonOptions, publication, dataCopyStatus, logger, linkedToken).ConfigureAwait(false);
+                        await ExportData(connection, publisher, writer, listenerOptions, jsonOptions, publication, dataCopyStatus, logger, linkedToken).ConfigureAwait(false);
+                    }
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/PgOutput2Json/DataExporter.cs
+++ b/src/PgOutput2Json/DataExporter.cs
@@ -1,0 +1,455 @@
+﻿using Microsoft.Extensions.Logging;
+using Npgsql;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PgOutput2Json
+{
+    internal static class DataExporter
+    {
+        public static async Task MaybeExportData(IMessagePublisher publisher,
+                                                 IMessageWriter writer,
+                                                 ReplicationListenerOptions listenerOptions,
+                                                 JsonOptions jsonOptions,
+                                                 CancellationToken token,
+                                                 ILogger? logger)
+        {
+            if (!listenerOptions.CopyData)
+            {
+                return;
+            }
+
+            using var connection = new NpgsqlConnection(listenerOptions.ConnectionString);
+
+            await connection.OpenAsync(token).ConfigureAwait(false);
+
+            var publications = await GetPublicationInfo(connection, listenerOptions, token).ConfigureAwait(false);
+
+            var json = new StringBuilder(256);
+            var keyVal = new StringBuilder(256);
+
+            foreach (var publication in publications)
+            {
+                var dataCopyStatus = await publisher.GetDataCopyStatus(publication.TableName, token).ConfigureAwait(false);
+
+                if (dataCopyStatus.IsCompleted) continue;
+
+                logger.SafeLogInfo("Exporting data from table {TableName} {RowFilter}", publication.TableName, publication.RowFilter);
+
+                await ExportData(connection, publisher, writer, listenerOptions, jsonOptions, publication, json, keyVal, token).ConfigureAwait(false);
+
+                await publisher.ReportDataCopyCompleted(publication.TableName, token).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task ExportData(NpgsqlConnection connection,
+                                             IMessagePublisher publisher,
+                                             IMessageWriter writer,
+                                             ReplicationListenerOptions listenerOptions,
+                                             JsonOptions jsonOptions,
+                                             PublicationInfo publication,
+                                             StringBuilder json,
+                                             StringBuilder keyVal,
+                                             CancellationToken token)
+        {
+            listenerOptions.IncludedColumns.TryGetValue(publication.TableName, out var includedColumns);
+            listenerOptions.TablePartitions.TryGetValue(publication.TableName, out var partitionCount);
+
+            // Export two columns to table data
+            var selectStatement = $"SELECT * FROM {publication.QuotedTableName}";
+            if (!string.IsNullOrWhiteSpace(publication.RowFilter))
+            {
+                selectStatement += " WHERE " + publication.RowFilter;
+            }
+
+            using var reader = connection.BeginTextExport($"COPY ({selectStatement}) TO STDOUT");
+
+            var currentBatch = 0;
+            var schemaWritten = false;
+
+            string? lastJsonString = null;
+
+            string? line;
+            while ((line = await reader.ReadLineAsync(token).ConfigureAwait(false)) != null)
+            {
+                var values = line.Split('\t');
+
+                if (values.Length != publication.Columns.Count) throw new Exception("Inconsistent column count between COPY output and table metadata");
+
+                json.Clear();
+                keyVal.Clear();
+
+                if (currentBatch == 0)
+                {
+                    currentBatch = listenerOptions.BatchSize;
+                }
+
+                json.Append("{\"c\":\"I\"");
+                json.Append(",\"w\":0");
+
+                if (jsonOptions.WriteTableNames)
+                {
+                    json.Append(",\"t\":\"");
+                    JsonUtils.EscapeText(json, publication.TableName);
+                    json.Append('"');
+                }
+
+                if (!schemaWritten)
+                {
+                    schemaWritten = true;
+
+                    json.Append(',');
+                    switch (jsonOptions.WriteMode)
+                    {
+                        case JsonWriteMode.Compact:
+                            WriteSchemaCompact(json, publication, includedColumns);
+                            break;
+                        default:
+                            WriteSchemaDefault(json, publication, includedColumns);
+                            break;
+                    }
+                }
+
+                var hash = WriteRow(publication.Columns, values, json, keyVal, jsonOptions, includedColumns);
+
+                json.Append('}');
+
+                var partition = partitionCount > 0 ? hash % partitionCount : 0;
+
+                lastJsonString = json.ToString();
+
+                await publisher.PublishAsync(0, lastJsonString, publication.TableName, keyVal.ToString(), partition, token).ConfigureAwait(false);
+
+                currentBatch--;
+                if (currentBatch <= 0)
+                {
+                    await publisher.ConfirmAsync(token).ConfigureAwait(false);
+
+                    await publisher.ReportDataCopyProgress(publication.TableName, lastJsonString, token).ConfigureAwait(false);
+                }
+            }
+
+            if (currentBatch > 0)
+            {
+                await publisher.ConfirmAsync(token).ConfigureAwait(false);
+
+                if (lastJsonString != null)
+                {
+                    await publisher.ReportDataCopyProgress(publication.TableName, lastJsonString, token).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private static int WriteRow(IReadOnlyList<ColumnInfo> cols,
+                                    string[] values,
+                                    StringBuilder json,
+                                    StringBuilder keyVal,
+                                    JsonOptions jsonOptions,
+                                    IReadOnlyList<string>? includedCols)
+        {
+            int finalHash = 0x12345678;
+
+            json.Append(",\"r\":");
+            json.Append(jsonOptions.WriteMode == JsonWriteMode.Compact ? '[' : '{');
+
+            var firstValue = true;
+
+            for (var i = 0; i < cols.Count; i++)
+            {
+                var colValue = values[i];
+
+                var isNull = colValue == @"\N";
+
+                // we must write nulls in compact mode to preserve the column indexes (no column names)
+                if (isNull && !jsonOptions.WriteNulls && jsonOptions.WriteMode != JsonWriteMode.Compact)
+                {
+                    continue;
+                }
+
+                var col = cols[i];
+
+                if (!IsIncluded(includedCols, col))
+                {
+                    continue;
+                }
+
+                if (col.IsKey)
+                {
+                    if (keyVal.Length == 0)
+                    {
+                        keyVal.Append('[');
+                    }
+                    else
+                    {
+                        keyVal.Append(',');
+                    }
+                }
+
+                if (!firstValue)
+                {
+                    json.Append(',');
+                }
+
+                firstValue = false;
+
+                if (jsonOptions.WriteMode != JsonWriteMode.Compact)
+                {
+                    // skip property name writing if we are in compact mode
+
+                    json.Append('"');
+                    JsonUtils.EscapeText(json, col.ColumnName);
+                    json.Append('"');
+                    json.Append(':');
+                }
+
+                if (isNull)
+                {
+                    json.Append("null");
+                    if (col.IsKey) keyVal.Append("null");
+                }
+                else
+                {
+                    var pgOid = (PgOid)col.DataTypeId;
+
+                    int hash;
+
+                    if (pgOid.IsNumber())
+                    {
+                        hash = JsonUtils.WriteNumber(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteNumber(keyVal, colValue);
+                    }
+                    else if (pgOid.IsBoolean())
+                    {
+                        hash = JsonUtils.WriteBoolean(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteBoolean(keyVal, colValue);
+                    }
+                    else if (pgOid.IsByte())
+                    {
+                        hash = JsonUtils.WriteByte(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteByte(keyVal, colValue);
+                    }
+                    else if (pgOid.IsArrayOfNumber())
+                    {
+                        hash = JsonUtils.WriteArrayOfNumber(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteArrayOfNumber(keyVal, colValue);
+                    }
+                    else if (pgOid.IsArrayOfByte())
+                    {
+                        hash = JsonUtils.WriteArrayOfByte(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteArrayOfByte(keyVal, colValue);
+                    }
+                    else if (pgOid.IsArrayOfBoolean())
+                    {
+                        hash = JsonUtils.WriteArrayOfBoolean(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteArrayOfBoolean(keyVal, colValue);
+                    }
+                    else if (pgOid.IsArrayOfText())
+                    {
+                        hash = JsonUtils.WriteArrayOfText(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteArrayOfText(keyVal, colValue);
+                    }
+                    else
+                    {
+                        hash = JsonUtils.WriteText(json, colValue);
+                        if (col.IsKey) JsonUtils.WriteText(keyVal, colValue);
+                    }
+
+                    if (col.IsKey) finalHash ^= hash;
+                }
+            }
+
+            if (keyVal.Length > 0 )
+            {
+                keyVal.Append(']');
+            }
+
+            json.Append(jsonOptions.WriteMode == JsonWriteMode.Compact ? ']' : '}');
+
+            return finalHash;
+        }
+
+        private static async Task<List<PublicationInfo>> GetPublicationInfo(NpgsqlConnection connection, ReplicationListenerOptions listenerOptions, CancellationToken token)
+        {
+            var result = new List<PublicationInfo>();
+
+            using (var cmd = connection.CreateCommand())
+            {
+                var pubNames = string.Join(',', listenerOptions.PublicationNames.Select(x => $"'{x}'"));
+
+                cmd.CommandText = $"SELECT schemaname, tablename, rowfilter FROM pg_catalog.pg_publication_tables WHERE pubname in ({pubNames}) ORDER BY schemaname, tablename";
+
+                using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+                while (await reader.ReadAsync(token).ConfigureAwait(false))
+                {
+                    result.Add(new PublicationInfo
+                    {
+                        TableName = $"{reader.GetString(0)}.{reader.GetString(1)}",
+                        QuotedTableName = $"\"{reader.GetString(0)}\".\"{reader.GetString(1)}\"",
+                        RowFilter = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    });
+                }
+            }
+
+            foreach (var publication in result)
+            {
+                await PopulateColumns(connection, publication, token).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+
+        private static async Task PopulateColumns(NpgsqlConnection connection, PublicationInfo publication, CancellationToken token)
+        {
+            using var cmd = connection.CreateCommand();
+
+            cmd.CommandText = $@"
+SELECT 
+    a.attname, 
+    a.atttypid, 
+    a.atttypmod, 
+    CASE WHEN i.indexrelid IS NOT NULL THEN true ELSE false END AS is_key
+FROM pg_attribute a
+LEFT JOIN
+    pg_index i ON i.indrelid = a.attrelid AND i.indisprimary AND a.attnum = ANY(i.indkey)
+WHERE
+    a.attrelid = '{publication.QuotedTableName}'::regclass
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+ORDER BY
+    a.attnum;
+";
+
+            using var reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false);
+
+            while (await reader.ReadAsync(token).ConfigureAwait(false))
+            {
+                publication.Columns.Add(new ColumnInfo
+                {
+                    ColumnName = reader.GetString(0),
+                    DataTypeId = (uint)reader.GetValue(1),
+                    TypeModifier = reader.GetInt32(2),
+                    IsKey = reader.GetBoolean(3),
+                });
+            }
+        }
+
+        private static bool IsIncluded(IReadOnlyList<string>? includedCols, ColumnInfo col)
+        {
+            if (includedCols == null) return true; // if not specified, included by default
+
+            foreach (var c in includedCols)
+            {
+                if (c == col.ColumnName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void WriteSchemaDefault(StringBuilder json, PublicationInfo publication, IReadOnlyList<string>? includedCols)
+        {
+            json.Append("\"schema\":{");
+
+            json.Append("\"tableName\":");
+            json.Append('"');
+            JsonUtils.EscapeText(json, publication.TableName);
+            json.Append('"');
+
+            json.Append(",\"columns\":[");
+
+            var i = 0;
+            foreach (var col in publication.Columns)
+            {
+                if (!IsIncluded(includedCols, col)) continue;
+
+                if (i > 0) json.Append(',');
+
+                json.Append('{');
+
+                json.Append("\"name\":");
+                json.Append('"');
+                JsonUtils.EscapeText(json, col.ColumnName);
+                json.Append('"');
+
+                json.Append(",\"isKey\":");
+                json.Append(col.IsKey ? "true" : "false");
+
+                json.Append(",\"dataType\":");
+                JsonUtils.EscapeText(json, col.DataTypeId.ToString());
+
+                if (col.TypeModifier != -1)
+                {
+                    json.Append(",\"typeModifier\":");
+                    JsonUtils.EscapeText(json, col.TypeModifier.ToString());
+                }
+
+                json.Append('}');
+                i++;
+            }
+
+            json.Append(']'); // columns
+            json.Append('}'); // schema
+        }
+
+        private static void WriteSchemaCompact(StringBuilder json, PublicationInfo pub, IReadOnlyList<string>? includedCols)
+        {
+            json.Append("\"s\":[");
+            json.Append('"');
+            JsonUtils.EscapeText(json, pub.TableName);
+            json.Append('"');
+
+            foreach (var col in pub.Columns)
+            {
+                if (!IsIncluded(includedCols, col)) continue;
+
+                json.Append(',');
+                json.Append('[');
+
+                json.Append('"');
+                JsonUtils.EscapeText(json, col.ColumnName);
+                json.Append('"');
+                json.Append(',');
+
+                json.Append(col.IsKey ? '1' : '0');
+                json.Append(',');
+
+                JsonUtils.EscapeText(json, col.DataTypeId.ToString());
+
+                if (col.TypeModifier != -1)
+                {
+                    json.Append(',');
+                    JsonUtils.EscapeText(json, col.TypeModifier.ToString());
+                }
+
+                json.Append(']');
+            }
+
+            json.Append(']');
+        }
+
+
+        private class PublicationInfo
+        {
+            public required string TableName { get; set; }
+            public required string QuotedTableName { get; set; }
+            public string? RowFilter { get; set; }
+
+            public List<ColumnInfo> Columns { get; set; } = [];
+        }
+
+        private class ColumnInfo
+        {
+            public required string ColumnName { get; set; }
+            public bool IsKey { get; set; }
+            public uint DataTypeId { get; set; }
+            public int TypeModifier { get; set; }
+        }
+    }
+}

--- a/src/PgOutput2Json/ILoggerExtensions.cs
+++ b/src/PgOutput2Json/ILoggerExtensions.cs
@@ -5,13 +5,13 @@ namespace PgOutput2Json
 {
     static class ILoggerExtensions
     {
-        public static void SafeLogDebug(this ILogger? logger, string message)
+        public static void SafeLogDebug(this ILogger? logger, string message, params object?[] args)
         {
             try
             {
                 if (logger != null && logger.IsEnabled(LogLevel.Debug))
                 {
-                    logger.LogDebug(message);
+                    logger.LogDebug(message, args);
                 }
             }
             catch
@@ -19,13 +19,13 @@ namespace PgOutput2Json
             }
         }
 
-        public static void SafeLogInfo(this ILogger? logger, string message)
+        public static void SafeLogInfo(this ILogger? logger, string message, params object?[] args)
         {
             try
             {
                 if (logger != null && logger.IsEnabled(LogLevel.Information))
                 {
-                    logger.LogInformation(message);
+                    logger.LogInformation(message, args);
                 }
             }
             catch
@@ -33,13 +33,13 @@ namespace PgOutput2Json
             }
         }
 
-        public static void SafeLogWarn(this ILogger? logger, string message)
+        public static void SafeLogWarn(this ILogger? logger, string message, params object?[] args)
         {
             try
             {
                 if (logger != null && logger.IsEnabled(LogLevel.Warning))
                 {
-                    logger.LogWarning(message);
+                    logger.LogWarning(message, args);
                 }
             }
             catch
@@ -47,13 +47,13 @@ namespace PgOutput2Json
             }
         }
 
-        public static void SafeLogError(this ILogger? logger, Exception ex, string message)
+        public static void SafeLogError(this ILogger? logger, Exception ex, string message, params object?[] args)
         {
             try
             {
                 if (logger != null && logger.IsEnabled(LogLevel.Error))
                 {
-                    logger.LogError(ex, message);
+                    logger.LogError(ex, message, args);
                 }
             }
             catch

--- a/src/PgOutput2Json/IMessagePublisher.cs
+++ b/src/PgOutput2Json/IMessagePublisher.cs
@@ -9,6 +9,6 @@ namespace PgOutput2Json
         Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token);
         Task ConfirmAsync(CancellationToken token);
 
-        Task<ulong> GetLastPublishedWalSeq(CancellationToken token);
+        Task<ulong?> GetLastPublishedWalSeq(CancellationToken token);
     }
 }

--- a/src/PgOutput2Json/IMessagePublisher.cs
+++ b/src/PgOutput2Json/IMessagePublisher.cs
@@ -10,6 +10,11 @@ namespace PgOutput2Json
         Task ConfirmAsync(CancellationToken token);
 
         Task<ulong> GetLastPublishedWalSeq(CancellationToken token);
+
+        Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token);
+        Task ReportDataCopyCompleted(string tableName, CancellationToken token);
+        
+        Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token);
     }
 
     public abstract class MessagePublisher : IMessagePublisher
@@ -23,5 +28,26 @@ namespace PgOutput2Json
             return Task.FromResult<ulong>(0);
         }
 
+        public virtual Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual Task ReportDataCopyCompleted(string tableName, CancellationToken token)
+        {
+            return Task.CompletedTask;
+        }
+
+        public virtual Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token)
+        {
+            return Task.FromResult(new DataCopyStatus { IsCompleted = false });
+        }
+    }
+
+    public class DataCopyStatus
+    {
+        public bool IsCompleted { get; set; }
+        public string? AdditionalRowFilter { get; set; }
+        public string? OrderByColumns { get; set; }
     }
 }

--- a/src/PgOutput2Json/IMessagePublisher.cs
+++ b/src/PgOutput2Json/IMessagePublisher.cs
@@ -9,6 +9,19 @@ namespace PgOutput2Json
         Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token);
         Task ConfirmAsync(CancellationToken token);
 
-        Task<ulong?> GetLastPublishedWalSeq(CancellationToken token);
+        Task<ulong> GetLastPublishedWalSeq(CancellationToken token);
+    }
+
+    public abstract class MessagePublisher : IMessagePublisher
+    {
+        public abstract Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token);
+        public abstract Task ConfirmAsync(CancellationToken token);
+        public abstract ValueTask DisposeAsync();
+
+        public virtual Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
+        {
+            return Task.FromResult<ulong>(0);
+        }
+
     }
 }

--- a/src/PgOutput2Json/IMessagePublisher.cs
+++ b/src/PgOutput2Json/IMessagePublisher.cs
@@ -47,7 +47,19 @@ namespace PgOutput2Json
     public class DataCopyStatus
     {
         public bool IsCompleted { get; set; }
+        public string? LastJson { get; set; }
+
+        /// <summary>
+        /// This is optionally populated by the client app, not used by the publisher.
+        /// It allows the client do decide where to continue the copy process, based on the lastJson exported
+        /// </summary>
         public string? AdditionalRowFilter { get; set; }
+
+        /// <summary>
+        /// This is optionally populated by the client app, not used by the publisher.
+        /// It is used in compbination with AdditionalRowFilter, and allows the client do decide where to continue the copy process, 
+        /// based on the lastJson exported
+        /// </summary>
         public string? OrderByColumns { get; set; }
     }
 }

--- a/src/PgOutput2Json/IMessagePublisher.cs
+++ b/src/PgOutput2Json/IMessagePublisher.cs
@@ -10,11 +10,6 @@ namespace PgOutput2Json
         Task ConfirmAsync(CancellationToken token);
 
         Task<ulong> GetLastPublishedWalSeq(CancellationToken token);
-
-        Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token);
-        Task ReportDataCopyCompleted(string tableName, CancellationToken token);
-        
-        Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token);
     }
 
     public abstract class MessagePublisher : IMessagePublisher
@@ -27,39 +22,5 @@ namespace PgOutput2Json
         {
             return Task.FromResult<ulong>(0);
         }
-
-        public virtual Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
-
-        public virtual Task ReportDataCopyCompleted(string tableName, CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
-
-        public virtual Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    public class DataCopyStatus
-    {
-        public bool IsCompleted { get; set; }
-        public string? LastJson { get; set; }
-
-        /// <summary>
-        /// This is optionally populated by the client app, not used by the publisher.
-        /// It allows the client do decide where to continue the copy process, based on the lastJson exported
-        /// </summary>
-        public string? AdditionalRowFilter { get; set; }
-
-        /// <summary>
-        /// This is optionally populated by the client app, not used by the publisher.
-        /// It is used in compbination with AdditionalRowFilter, and allows the client do decide where to continue the copy process, 
-        /// based on the lastJson exported
-        /// </summary>
-        public string? OrderByColumns { get; set; }
     }
 }

--- a/src/PgOutput2Json/IMessagePublisher.cs
+++ b/src/PgOutput2Json/IMessagePublisher.cs
@@ -30,17 +30,17 @@ namespace PgOutput2Json
 
         public virtual Task ReportDataCopyProgress(string tableName, string lastJson, CancellationToken token)
         {
-            return Task.CompletedTask;
+            throw new NotImplementedException();
         }
 
         public virtual Task ReportDataCopyCompleted(string tableName, CancellationToken token)
         {
-            return Task.CompletedTask;
+            throw new NotImplementedException();
         }
 
         public virtual Task<DataCopyStatus> GetDataCopyStatus(string tableName, CancellationToken token)
         {
-            return Task.FromResult(new DataCopyStatus { IsCompleted = false });
+            throw new NotImplementedException();
         }
     }
 

--- a/src/PgOutput2Json/MessageWriter.cs
+++ b/src/PgOutput2Json/MessageWriter.cs
@@ -18,7 +18,7 @@ namespace PgOutput2Json
     {
         public int Partition;
         public string Json = "";
-        public string TableNames = "";
+        public string TableName = "";
         public string KeyKolValue = "";
     }
 
@@ -121,7 +121,7 @@ namespace PgOutput2Json
 
             _result.Partition = partition;
             _result.Json = _jsonBuilder.ToString();
-            _result.TableNames = _tableNameBuilder.ToString();
+            _result.TableName = _tableNameBuilder.ToString();
             _result.KeyKolValue = _keyColValueBuilder.ToString();
 
             return _result;

--- a/src/PgOutput2Json/MessageWriterOld.cs
+++ b/src/PgOutput2Json/MessageWriterOld.cs
@@ -79,7 +79,7 @@ namespace PgOutput2Json
 
             _result.Partition = partition;
             _result.Json = _jsonBuilder.ToString();
-            _result.TableNames = _tableNameBuilder.ToString();
+            _result.TableName = _tableNameBuilder.ToString();
             _result.KeyKolValue = _keyColValueBuilder.ToString();
 
             return _result;

--- a/src/PgOutput2Json/PgOid.cs
+++ b/src/PgOutput2Json/PgOid.cs
@@ -2,7 +2,7 @@
 {
     // taken from: https://github.com/postgres/postgres/blob/90260e2ec6bbfc3dfa9d9501ab75c535de52f677/src/include/catalog/pg_type.dat
 
-    public enum PgOid
+    public enum PgOid: uint
     {
         BOOLOID = 16,
         BYTEAOID = 17,

--- a/src/PgOutput2Json/PgOid.cs
+++ b/src/PgOutput2Json/PgOid.cs
@@ -68,7 +68,7 @@
         A_XMLOID = 143, // array of xml
     }
 
-    internal static class PgOidExtensions
+    public static class PgOidExtensions
     {
         public static bool IsNumber(this PgOid pgOid)
         {
@@ -119,6 +119,13 @@
         {
             return pgOid == PgOid.A_BYTEAOID;
         }
+
+        public static bool IsTimestamp(this PgOid pgOid)
+        {
+            return pgOid == PgOid.TIMESTAMPOID
+                || pgOid == PgOid.TIMESTAMPTZOID;
+        }
+
 
         /*
         public static bool IsArray(this PgOid pgOid)

--- a/src/PgOutput2Json/PgOutput2JsonBuilder.cs
+++ b/src/PgOutput2Json/PgOutput2JsonBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace PgOutput2Json
 {
@@ -139,7 +140,11 @@ namespace PgOutput2Json
                 throw new ArgumentOutOfRangeException("Replication slot name must be provided for permanent slots");
             }
 
-            var options = new ReplicationListenerOptions(_connectionString,
+            var cnStringBuilder = new NpgsqlConnectionStringBuilder(_connectionString);
+
+            cnStringBuilder.Timezone ??= "UTC";
+
+            var options = new ReplicationListenerOptions(cnStringBuilder.ConnectionString,
                                                          _useTemporarySlot,
                                                          _replicationSlotName,
                                                          _publicationNames,

--- a/src/PgOutput2Json/PgOutput2JsonBuilder.cs
+++ b/src/PgOutput2Json/PgOutput2JsonBuilder.cs
@@ -21,6 +21,8 @@ namespace PgOutput2Json
         private int _batchSize = 100;
 
         private bool _copyData = false;
+        private int _maxParallelCopyJobs = 1;
+
         private Action<string, DataCopyStatus>? _dataCopyStatusHandler;
 
         public static PgOutput2JsonBuilder Create()
@@ -112,9 +114,10 @@ namespace PgOutput2Json
             return this;
         }
 
-        public PgOutput2JsonBuilder CopyData(bool copyData = false)
+        public PgOutput2JsonBuilder WithInitialDataCopy(bool copyData = false, int maxParallelJobs = 1)
         {
             _copyData = copyData;
+            _maxParallelCopyJobs = maxParallelJobs;
             return this;
         }
 
@@ -152,6 +155,8 @@ namespace PgOutput2Json
 
             cnStringBuilder.Timezone ??= "UTC";
 
+            if (_maxParallelCopyJobs <= 0) _maxParallelCopyJobs = 1;
+
             var options = new ReplicationListenerOptions(cnStringBuilder.ConnectionString,
                                                          _useTemporarySlot,
                                                          _replicationSlotName,
@@ -162,6 +167,7 @@ namespace PgOutput2Json
                                                          _columns,
                                                          _partitionFilter,
                                                          _copyData,
+                                                         _maxParallelCopyJobs,
                                                          _dataCopyStatusHandler);
 
             var listener = new ReplicationListener(_messagePublisherFactory, options, _jsonOptions, _loggerFactory);

--- a/src/PgOutput2Json/PgOutput2JsonBuilder.cs
+++ b/src/PgOutput2Json/PgOutput2JsonBuilder.cs
@@ -18,6 +18,7 @@ namespace PgOutput2Json
         private PartitionFilter? _partitionFilter;
         private bool _useTemporarySlot = true;
         private int _batchSize = 100;
+        private bool _copyData = false;
 
         public static PgOutput2JsonBuilder Create()
         {
@@ -108,6 +109,12 @@ namespace PgOutput2Json
             return this;
         }
 
+        public PgOutput2JsonBuilder CopyData(bool copyData = false)
+        {
+            _copyData = copyData;
+            return this;
+        }
+
         public IPgOutput2Json Build()
         {
             if (string.IsNullOrWhiteSpace(_connectionString)) 
@@ -140,7 +147,8 @@ namespace PgOutput2Json
                                                          _batchSize,
                                                          _tablePartitions,
                                                          _columns,
-                                                         _partitionFilter);
+                                                         _partitionFilter,
+                                                         _copyData);
 
             var listener = new ReplicationListener(_messagePublisherFactory, options, _jsonOptions, _loggerFactory);
 

--- a/src/PgOutput2Json/PgOutput2JsonBuilder.cs
+++ b/src/PgOutput2Json/PgOutput2JsonBuilder.cs
@@ -19,7 +19,9 @@ namespace PgOutput2Json
         private PartitionFilter? _partitionFilter;
         private bool _useTemporarySlot = true;
         private int _batchSize = 100;
+
         private bool _copyData = false;
+        private Action<string, DataCopyStatus>? _dataCopyStatusHandler;
 
         public static PgOutput2JsonBuilder Create()
         {
@@ -116,6 +118,12 @@ namespace PgOutput2Json
             return this;
         }
 
+        public PgOutput2JsonBuilder WithDataCopyStatusHandler(Action<string, DataCopyStatus> handler)
+        {
+            _dataCopyStatusHandler = handler;
+            return this;
+        }
+
         public IPgOutput2Json Build()
         {
             if (string.IsNullOrWhiteSpace(_connectionString)) 
@@ -153,7 +161,8 @@ namespace PgOutput2Json
                                                          _tablePartitions,
                                                          _columns,
                                                          _partitionFilter,
-                                                         _copyData);
+                                                         _copyData,
+                                                         _dataCopyStatusHandler);
 
             var listener = new ReplicationListener(_messagePublisherFactory, options, _jsonOptions, _loggerFactory);
 

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -49,7 +49,7 @@ namespace PgOutput2Json
 
                     if (_loggerFactory != null) Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(_loggerFactory);
 
-                    var _lastWalEnd = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeq(cancellationToken) ?? 0);
+                    var _lastWalEnd = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeq(cancellationToken).ConfigureAwait(false));
 
                     var connection = new LogicalReplicationConnection(_options.ConnectionString);
 

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -51,8 +51,6 @@ namespace PgOutput2Json
 
                     if (_loggerFactory != null) Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(_loggerFactory);
 
-                    await DataExporter.MaybeExportData(messagePublisher, _writer, _options, _jsonOptions, cancellationToken, _logger).ConfigureAwait(false);
-                    
                     var _lastWalEnd = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeq(cancellationToken).ConfigureAwait(false));
 
                     var connection = new LogicalReplicationConnection(_options.ConnectionString);
@@ -81,6 +79,9 @@ namespace PgOutput2Json
                             slot = await connection.CreatePgOutputReplicationSlot(slotName, true, cancellationToken: cancellationToken)
                                 .ConfigureAwait(false);
                         }
+                    
+                        // start data export after creating the temporary replication slot
+                        await DataExporter.MaybeExportData(messagePublisher, _writer, _options, _jsonOptions, _logger, cancellationToken).ConfigureAwait(false);
 
                         var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
 

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -49,7 +49,7 @@ namespace PgOutput2Json
 
                     if (_loggerFactory != null) Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(_loggerFactory);
 
-                    var _lastWalEnd = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeq(cancellationToken));
+                    var _lastWalEnd = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeq(cancellationToken) ?? 0);
 
                     var connection = new LogicalReplicationConnection(_options.ConnectionString);
 

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -16,6 +16,8 @@ namespace PgOutput2Json
         private readonly ILogger<ReplicationListener>? _logger;
 
         private readonly ReplicationListenerOptions _options;
+        private readonly JsonOptions _jsonOptions;
+
         private readonly IMessageWriter _writer;
 
         private readonly IMessagePublisherFactory _messagePublisherFactory;
@@ -29,7 +31,7 @@ namespace PgOutput2Json
         {
             _messagePublisherFactory = messagePublisherFactory;
             _options = options;
-
+            _jsonOptions = jsonOptions;
             _writer = jsonOptions.UseOldFormat
                 ? new MessageWriterOld(jsonOptions, options)
                 : new MessageWriter(jsonOptions, options);
@@ -49,6 +51,8 @@ namespace PgOutput2Json
 
                     if (_loggerFactory != null) Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(_loggerFactory);
 
+                    await DataExporter.MaybeExportData(messagePublisher, _writer, _options, _jsonOptions, cancellationToken, _logger).ConfigureAwait(false);
+                    
                     var _lastWalEnd = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeq(cancellationToken).ConfigureAwait(false));
 
                     var connection = new LogicalReplicationConnection(_options.ConnectionString);

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -81,7 +81,7 @@ namespace PgOutput2Json
                         }
                     
                         // start data export after creating the temporary replication slot
-                        await DataExporter.MaybeExportData(messagePublisher, _writer, _options, _jsonOptions, _logger, cancellationToken).ConfigureAwait(false);
+                        await DataExporter.MaybeExportData(_messagePublisherFactory, _writer, _options, _jsonOptions, _loggerFactory, cancellationToken).ConfigureAwait(false);
 
                         var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
 

--- a/src/PgOutput2Json/ReplicationListenerOptions.cs
+++ b/src/PgOutput2Json/ReplicationListenerOptions.cs
@@ -24,6 +24,8 @@ namespace PgOutput2Json
         /// </summary>
         public bool CopyData { get; private set; } = false;
 
+        public Action<string, DataCopyStatus> DataCopyStatusHandler { get; private set; }
+
         public ReplicationListenerOptions(string connectionString,
                                           bool useTemporarySlot,
                                           string replicationSlotName,
@@ -33,7 +35,8 @@ namespace PgOutput2Json
                                           IReadOnlyDictionary<string, int> tablePartitions,
                                           IReadOnlyDictionary<string, IReadOnlyList<string>> includedColumns, 
                                           PartitionFilter? partitionFilter = null,
-                                          bool copyData = false)
+                                          bool copyData = false,
+                                          Action<string, DataCopyStatus>? dataCopyStatusHandler = null)
         {
             ConnectionString = connectionString;
             UseTemporarySlot = useTemporarySlot;
@@ -45,6 +48,7 @@ namespace PgOutput2Json
             IncludedColumns = new Dictionary<string, IReadOnlyList<string>>(includedColumns);
             PartitionFilter = partitionFilter;
             CopyData = copyData;
+            DataCopyStatusHandler = dataCopyStatusHandler ?? ((tableName, status) => { });
         }
     }
 }

--- a/src/PgOutput2Json/ReplicationListenerOptions.cs
+++ b/src/PgOutput2Json/ReplicationListenerOptions.cs
@@ -22,7 +22,9 @@ namespace PgOutput2Json
         /// The publisher must support storing the last WAL LSN, because it is used to decide weather to initiate the copy or not.
         /// The copy is initiated only if the last published WAL LSN == 0.
         /// </summary>
-        public bool CopyData { get; private set; } = false;
+        public bool CopyData { get; private set; }
+
+        public int MaxParallelCopyJobs { get; private set; }
 
         public Action<string, DataCopyStatus> DataCopyStatusHandler { get; private set; }
 
@@ -36,6 +38,7 @@ namespace PgOutput2Json
                                           IReadOnlyDictionary<string, IReadOnlyList<string>> includedColumns, 
                                           PartitionFilter? partitionFilter = null,
                                           bool copyData = false,
+                                          int maxParallelCopyJobs = 1,
                                           Action<string, DataCopyStatus>? dataCopyStatusHandler = null)
         {
             ConnectionString = connectionString;
@@ -48,6 +51,7 @@ namespace PgOutput2Json
             IncludedColumns = new Dictionary<string, IReadOnlyList<string>>(includedColumns);
             PartitionFilter = partitionFilter;
             CopyData = copyData;
+            MaxParallelCopyJobs = maxParallelCopyJobs;
             DataCopyStatusHandler = dataCopyStatusHandler ?? ((tableName, status) => { });
         }
     }

--- a/src/PgOutput2Json/ReplicationListenerOptions.cs
+++ b/src/PgOutput2Json/ReplicationListenerOptions.cs
@@ -17,6 +17,13 @@ namespace PgOutput2Json
         public Dictionary<string, IReadOnlyList<string>> IncludedColumns { get; private set; }
         public PartitionFilter? PartitionFilter { get; private set; }
 
+        /// <summary>
+        /// Push the existing data to the publisher. Default is false.
+        /// The publisher must support storing the last WAL LSN, because it is used to decide weather to initiate the copy or not.
+        /// The copy is initiated only if the last published WAL LSN == 0.
+        /// </summary>
+        public bool CopyData { get; private set; } = false;
+
         public ReplicationListenerOptions(string connectionString,
                                           bool useTemporarySlot,
                                           string replicationSlotName,
@@ -25,7 +32,8 @@ namespace PgOutput2Json
                                           int batchSize,
                                           IReadOnlyDictionary<string, int> tablePartitions,
                                           IReadOnlyDictionary<string, IReadOnlyList<string>> includedColumns, 
-                                          PartitionFilter? partitionFilter = null)
+                                          PartitionFilter? partitionFilter = null,
+                                          bool copyData = false)
         {
             ConnectionString = connectionString;
             UseTemporarySlot = useTemporarySlot;
@@ -36,6 +44,7 @@ namespace PgOutput2Json
             TablePartitions = new Dictionary<string, int>(tablePartitions);
             IncludedColumns = new Dictionary<string, IReadOnlyList<string>>(includedColumns);
             PartitionFilter = partitionFilter;
+            CopyData = copyData;
         }
     }
 }

--- a/src/PgOutput2Json/SimpleMessagePublisher.cs
+++ b/src/PgOutput2Json/SimpleMessagePublisher.cs
@@ -21,7 +21,7 @@ namespace PgOutput2Json
         }
     }
 
-    internal class SimpleMessagePublisher : IMessagePublisher
+    internal class SimpleMessagePublisher : MessagePublisher
     {
         private readonly SimpleMessageHandler _messageHandler;
         private readonly ILogger<SimpleMessagePublisher>? _logger;
@@ -32,26 +32,21 @@ namespace PgOutput2Json
             _logger = logger;
         }
 
-        public Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token) 
+        public override Task PublishAsync(ulong walSeqNo, string json, string tableName, string keyColumnValue, int partition, CancellationToken token) 
         {
             _logger?.LogDebug("Message for {Table}: {Json}", tableName, json);
 
             return _messageHandler.Invoke(json, tableName, keyColumnValue, partition);
         }
 
-        public Task ConfirmAsync(CancellationToken token)
+        public override Task ConfirmAsync(CancellationToken token)
         {
             return Task.CompletedTask;
         }
 
-        public ValueTask DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
             return ValueTask.CompletedTask;
-        }
-
-        public Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
-        {
-            return Task.FromResult<ulong?>(null);
         }
     }
 }

--- a/src/PgOutput2Json/SimpleMessagePublisher.cs
+++ b/src/PgOutput2Json/SimpleMessagePublisher.cs
@@ -49,9 +49,9 @@ namespace PgOutput2Json
             return ValueTask.CompletedTask;
         }
 
-        public Task<ulong> GetLastPublishedWalSeq(CancellationToken token)
+        public Task<ulong?> GetLastPublishedWalSeq(CancellationToken token)
         {
-            return Task.FromResult(0ul);
+            return Task.FromResult<ulong?>(null);
         }
     }
 }


### PR DESCRIPTION
### Summary:
Implement initial data copy (optional) on replication listener startup with support for resuming from interruption.

### Details:
- Added functionality for initial copying of existing data when the replication listener is started.
- Introduced the requirement for a database named `pg_output2json` to track copied tables and store the last message for each table. This is **only required if data copy is enabled**.
- Users can customize the continuation of data copying in case of interruption by configuring the `PgOutput2JsonBuilder` with `WithDataCopyStatusHandler(...)`.
- The handler provides the table name and the last JSON sent, allowing users to parse the JSON and define the order by and additional filters to resume the process from where it left off.
- **Data copy is off by default** and must be explicitly enabled using `WithInitialDataCopy(true)` in the builder.

### Notes:
- Ensure that the `pg_output2json` database is created **only if data copy is enabled** before starting the replication listener.
