### PR TITLE
Allow awaiting for a specific wal LSN

### DIFF
--- a/src/PgOutput2Json.Kafka/PgOutput2Json.Kafka.csproj
+++ b/src/PgOutput2Json.Kafka/PgOutput2Json.Kafka.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<Version>0.9.14</Version>
+	<Version>0.9.15</Version>
     <RepositoryUrl>https://github.com/PgOutput2Json/PgOutput2Json</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>PgOutput2Json</Authors>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="PgOutput2Json" Version="0.9.14" />
+    <PackageReference Include="PgOutput2Json" Version="0.9.15" />
   </ItemGroup>
 
 

--- a/src/PgOutput2Json.RabbitMq/PgOutput2Json.RabbitMq.csproj
+++ b/src/PgOutput2Json.RabbitMq/PgOutput2Json.RabbitMq.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.9.14</Version>
+    <Version>0.9.15</Version>
     <RepositoryUrl>https://github.com/PgOutput2Json/PgOutput2Json</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>PgOutput2Json</Authors>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="PgOutput2Json" Version="0.9.14" />
+    <PackageReference Include="PgOutput2Json" Version="0.9.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PgOutput2Json.RabbitMqStreams/PgOutput2Json.RabbitMqStreams.csproj
+++ b/src/PgOutput2Json.RabbitMqStreams/PgOutput2Json.RabbitMqStreams.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.9.14</Version>
+    <Version>0.9.15</Version>
     <RepositoryUrl>https://github.com/PgOutput2Json/PgOutput2Json</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>PgOutput2Json</Authors>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="PgOutput2Json" Version="0.9.14" />
+    <PackageReference Include="PgOutput2Json" Version="0.9.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PgOutput2Json.Redis/PgOutput2Json.Redis.csproj
+++ b/src/PgOutput2Json.Redis/PgOutput2Json.Redis.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.9.14</Version>
+    <Version>0.9.15</Version>
     <RepositoryUrl>https://github.com/PgOutput2Json/PgOutput2Json</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>PgOutput2Json</Authors>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="PgOutput2Json" Version="0.9.14" />
+    <PackageReference Include="PgOutput2Json" Version="0.9.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PgOutput2Json.Sqlite/PgOutput2Json.Sqlite.csproj
+++ b/src/PgOutput2Json.Sqlite/PgOutput2Json.Sqlite.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.9.14</Version>
+    <Version>0.9.15</Version>
     <RepositoryUrl>https://github.com/PgOutput2Json/PgOutput2Json</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>PgOutput2Json</Authors>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="PgOutput2Json" Version="0.9.14" />
+    <PackageReference Include="PgOutput2Json" Version="0.9.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PgOutput2Json.TestWorker/PgOutput2Json.TestWorker.csproj
+++ b/src/PgOutput2Json.TestWorker/PgOutput2Json.TestWorker.csproj
@@ -16,11 +16,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' == 'Release'">
-    <PackageReference Include="PgOutput2Json.Kafka" Version="0.9.14" />
-    <PackageReference Include="PgOutput2Json.RabbitMq" Version="0.9.14" />
-    <PackageReference Include="PgOutput2Json.RabbitMqStreams" Version="0.9.14" />
-    <PackageReference Include="PgOutput2Json.Redis" Version="0.9.14" />
-    <PackageReference Include="PgOutput2Json.Sqlite" Version="0.9.14" />
+    <PackageReference Include="PgOutput2Json.Kafka" Version="0.9.15" />
+    <PackageReference Include="PgOutput2Json.RabbitMq" Version="0.9.15" />
+    <PackageReference Include="PgOutput2Json.RabbitMqStreams" Version="0.9.15" />
+    <PackageReference Include="PgOutput2Json.Redis" Version="0.9.15" />
+    <PackageReference Include="PgOutput2Json.Sqlite" Version="0.9.15" />
   </ItemGroup>
 
 

--- a/src/PgOutput2Json/DataExporter.cs
+++ b/src/PgOutput2Json/DataExporter.cs
@@ -12,7 +12,6 @@ namespace PgOutput2Json
     internal static class DataExporter
     {
         public static async Task MaybeExportData(IMessagePublisherFactory publisherFactory,
-                                                 IMessageWriter writer,
                                                  ReplicationListenerOptions listenerOptions,
                                                  JsonOptions jsonOptions,
                                                  ILoggerFactory? loggerFactory,
@@ -67,7 +66,7 @@ namespace PgOutput2Json
 
                     while (!linkedToken.IsCancellationRequested)
                     {
-                        var completed = await ExportData(connection, publisher, writer, listenerOptions, jsonOptions, publication, dataCopyStatus, logger, linkedToken).ConfigureAwait(false);
+                        var completed = await ExportData(connection, publisher, listenerOptions, jsonOptions, publication, dataCopyStatus, logger, linkedToken).ConfigureAwait(false);
                         if (completed) break;
 
                         // needed for continuation of the next batch
@@ -95,14 +94,13 @@ namespace PgOutput2Json
         }
 
         private static async Task<bool> ExportData(NpgsqlConnection connection,
-                                             IMessagePublisher publisher,
-                                             IMessageWriter writer,
-                                             ReplicationListenerOptions listenerOptions,
-                                             JsonOptions jsonOptions,
-                                             PublicationInfo publication,
-                                             DataCopyStatus dataCopyStatus,
-                                             ILogger? logger,
-                                             CancellationToken cancellationToken)
+                                                   IMessagePublisher publisher,
+                                                   ReplicationListenerOptions listenerOptions,
+                                                   JsonOptions jsonOptions,
+                                                   PublicationInfo publication,
+                                                   DataCopyStatus dataCopyStatus,
+                                                   ILogger? logger,
+                                                   CancellationToken cancellationToken)
         {
             string? lastJsonString = null;
 

--- a/src/PgOutput2Json/IPgOutput2Json.cs
+++ b/src/PgOutput2Json/IPgOutput2Json.cs
@@ -7,5 +7,8 @@ namespace PgOutput2Json
     public interface IPgOutput2Json: IDisposable
     {
         Task Start(CancellationToken cancellationToken);
+
+        Task<bool> WhenReplicationStarts(TimeSpan timeout, CancellationToken cancellationToken);
+        Task<bool> WhenLsnReaches(string expectedLsn, TimeSpan timeout, CancellationToken cancellationToken);
     }
 }

--- a/src/PgOutput2Json/PgOutput2Json.csproj
+++ b/src/PgOutput2Json/PgOutput2Json.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<Version>0.9.14</Version>
+	<Version>0.9.15</Version>
     <RepositoryUrl>https://github.com/PgOutput2Json/PgOutput2Json</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>PgOutput2Json</Authors>

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -81,7 +81,7 @@ namespace PgOutput2Json
                         }
                     
                         // start data export after creating the temporary replication slot
-                        await DataExporter.MaybeExportData(_messagePublisherFactory, _writer, _options, _jsonOptions, _loggerFactory, cancellationToken).ConfigureAwait(false);
+                        await DataExporter.MaybeExportData(_messagePublisherFactory, _options, _jsonOptions, _loggerFactory, cancellationToken).ConfigureAwait(false);
 
                         var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
 


### PR DESCRIPTION
This may be useful in cache implementation - after writing to Postgres, a client could get the latest LSN, then wait for it to make sure the cache has the latest change.