### PR TITLE
Implement virtual LSN for deduplication

### DIFF
--- a/src/PgOutput2Json/IPgOutput2Json.cs
+++ b/src/PgOutput2Json/IPgOutput2Json.cs
@@ -7,8 +7,9 @@ namespace PgOutput2Json
     public interface IPgOutput2Json: IDisposable
     {
         Task StartAsync(CancellationToken cancellationToken);
-
+        /*
         Task<bool> WhenReplicationStartsAsync(TimeSpan timeout, CancellationToken cancellationToken);
         Task<bool> WhenLsnReachesAsync(string expectedLsn, TimeSpan timeout, CancellationToken cancellationToken);
+        */
     }
 }

--- a/src/PgOutput2Json/JsonOptions.cs
+++ b/src/PgOutput2Json/JsonOptions.cs
@@ -28,8 +28,6 @@
         /// </summary>
         public bool WriteTableNames { get; set; }
 
-        public bool WriteWalStart { get; set; }
-
         /// <summary>
         /// If set to Compact, the JSON values will be written as arrays, without column names.
         /// Column names will be sent in a separate "s" (schema) property, when a Relation message is encountered.

--- a/src/PgOutput2Json/JsonWriter.cs
+++ b/src/PgOutput2Json/JsonWriter.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Npgsql.Replication.PgOutput;
 using Npgsql.Replication.PgOutput.Messages;
+using NpgsqlTypes;
 
 namespace PgOutput2Json
 {
@@ -35,7 +36,7 @@ namespace PgOutput2Json
             _listenerOptions = listenerOptions;
         }
 
-        public async Task<JsonMessage> WriteMessageAsync(ReplicationMessage replMessage, CancellationToken token)
+        public async Task<JsonMessage> WriteMessageAsync(ReplicationMessage replMessage, NpgsqlLogSequenceNumber virtualLsn, CancellationToken token)
         {
             var partition = -1;
 
@@ -52,6 +53,7 @@ namespace PgOutput2Json
                                                   "I",
                                                   commitTimeStamp,
                                                   hasRelationChanged,
+                                                  virtualLsn,
                                                   token)
                     .ConfigureAwait(false);
             }
@@ -64,6 +66,7 @@ namespace PgOutput2Json
                                                   "U",
                                                   commitTimeStamp,
                                                   hasRelationChanged,
+                                                  virtualLsn,
                                                   token)
                     .ConfigureAwait(false);
             }
@@ -76,6 +79,7 @@ namespace PgOutput2Json
                                                   "U",
                                                   commitTimeStamp,
                                                   hasRelationChanged,
+                                                  virtualLsn,
                                                   token)
                     .ConfigureAwait(false);
             }
@@ -88,6 +92,7 @@ namespace PgOutput2Json
                                                   "U",
                                                   commitTimeStamp,
                                                   hasRelationChanged,
+                                                  virtualLsn,
                                                   token)
                     .ConfigureAwait(false);
             }
@@ -100,6 +105,7 @@ namespace PgOutput2Json
                                                   "D",
                                                   commitTimeStamp,
                                                   hasRelationChanged,
+                                                  virtualLsn,
                                                   token)
                     .ConfigureAwait(false);
             }
@@ -112,6 +118,7 @@ namespace PgOutput2Json
                                                   "D",
                                                   commitTimeStamp,
                                                   hasRelationChanged,
+                                                  virtualLsn,
                                                   token)
                     .ConfigureAwait(false);
             }
@@ -129,6 +136,7 @@ namespace PgOutput2Json
                                                 string changeType,
                                                 DateTime commitTimeStamp,
                                                 bool hasRelationChanged,
+                                                NpgsqlLogSequenceNumber virtualLsn,
                                                 CancellationToken cancellationToken)
         {
             TableNameBuilder.Clear();
@@ -143,14 +151,8 @@ namespace PgOutput2Json
             JsonBuilder.Append(changeType);
             JsonBuilder.Append('"');
 
-            if (_jsonOptions.WriteWalStart)
-            {
-                JsonBuilder.Append(",\"ws\":");
-                JsonBuilder.Append((ulong)msg.WalStart);
-            }
-
             JsonBuilder.Append(",\"w\":");
-            JsonBuilder.Append((ulong)msg.WalEnd);
+            JsonBuilder.Append((ulong)virtualLsn);
 
             if (_jsonOptions.WriteTimestamps)
             {

--- a/src/PgOutput2Json/PgOutput2Json.cs
+++ b/src/PgOutput2Json/PgOutput2Json.cs
@@ -38,6 +38,7 @@ namespace PgOutput2Json
             }
         }
 
+        /*
         public Task<bool> WhenReplicationStartsAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             return WhenLsnReachesAsync("0/0", timeout, cancellationToken);
@@ -59,6 +60,7 @@ namespace PgOutput2Json
                 throw;
             }
         }
+        */
 
         public void Dispose()
         {


### PR DESCRIPTION
Since it seems (from what I could gather) one XLogData message may contain more than one wal record, we're calculating virtual LSN for deduplication purposes.

We Track last_start_lsn and virtual_lsn, so when new XLogData arrives:

If start_lsn == last_start_lsn: increment virtual_lsn++
If start_lsn > last_start_lsn: set virtual_lsn = start_lsn

For example:

XLogData start_lsn=1000: BEGIN (virtual_lsn=1000), INSERT (virtual_lsn=1001)
XLogData start_lsn=2000: COMMIT (virtual_lsn=2000)
XLogData start_lsn=2000: BEGIN (virtual_lsn=2001), INSERT (virtual_lsn=2002)