### PR TITLE
Implement support for RabbitMq Super Streams

### DIFF
--- a/src/PgOutput2Json.RabbitMqStreams/ApplicationProperties.cs
+++ b/src/PgOutput2Json.RabbitMqStreams/ApplicationProperties.cs
@@ -1,0 +1,7 @@
+﻿namespace PgOutput2Json.RabbitMqStreams
+{
+    internal static class ApplicationProperties
+    {
+        public const string PartitionKey = "PartitionKey";
+    }
+}

--- a/src/PgOutput2Json.RabbitMqStreams/PgOutput2Json.RabbitMqStreams.csproj
+++ b/src/PgOutput2Json.RabbitMqStreams/PgOutput2Json.RabbitMqStreams.csproj
@@ -48,7 +48,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="RabbitMQ.Stream.Client" Version="1.9.0" />
+        <PackageReference Include="RabbitMQ.Stream.Client" Version="1.9.1" />
     </ItemGroup>
 
 </Project>

--- a/src/PgOutput2Json.RabbitMqStreams/RabbitMqStreamsPublisherOptions.cs
+++ b/src/PgOutput2Json.RabbitMqStreams/RabbitMqStreamsPublisherOptions.cs
@@ -1,10 +1,19 @@
 ﻿using RabbitMQ.Stream.Client;
+using RabbitMQ.Stream.Client.Reliable;
+using System;
 
 namespace PgOutput2Json.RabbitMqStreams
 {
     public class RabbitMqStreamsPublisherOptions
     {
         public string StreamName { get; set; } = "pgoutput2json";
+
+        /// <summary>
+        /// Default is false
+        /// </summary>
+        public bool WriteTableNameToMessageKey { get; set; }
+        
+        public bool IsSuperStream { get; set; }
 
         /// <summary>
         /// Number of the messages sent for each frame-send.<br/>
@@ -14,7 +23,6 @@ namespace PgOutput2Json.RabbitMqStreams
         /// </summary>
         public int MessageBufferSize { get; set; } = 100;
 
-
         public StreamSystemConfig StreamSystemConfig { get; set; } = new StreamSystemConfig
         {
             UserName = "guest",
@@ -23,6 +31,19 @@ namespace PgOutput2Json.RabbitMqStreams
             Endpoints = [],
 
             ClientProvidedName = "PgOutput2Json",
+        };
+
+        public SuperStreamConfig SuperStreamConfig { get; set; } = new SuperStreamConfig
+        {
+            Routing = msg =>
+            {
+                return msg.ApplicationProperties != null
+                    && msg.ApplicationProperties.TryGetValue(ApplicationProperties.PartitionKey, out var partitionKey)
+                    && partitionKey != null
+                    ? partitionKey.ToString()
+                    : msg.Properties?.MessageId?.ToString() ?? Guid.NewGuid().ToString();
+            },
+            RoutingStrategyType = RoutingStrategyType.Hash,
         };
     }
 }

--- a/src/PgOutput2Json.TestWorker/Worker.cs
+++ b/src/PgOutput2Json.TestWorker/Worker.cs
@@ -74,6 +74,7 @@ namespace PgOutput2Json.TestWorker
                 //.UseRabbitMqStreams(options =>
                 //{
                 //    options.StreamName = "test_stream";
+                //    options.IsSuperStream = false;
                 //    options.StreamSystemConfig.UserName = "guest";
                 //    options.StreamSystemConfig.Password = "guest";
                 //    options.StreamSystemConfig.VirtualHost = "/";


### PR DESCRIPTION
By default, PK is used for hash routing, but if the user provides partition key fields, they will be used instead.