### PR TITLE
Implement idle wal message

### DIFF
--- a/src/PgOutput2Json/DisposableExtensions.cs
+++ b/src/PgOutput2Json/DisposableExtensions.cs
@@ -76,7 +76,31 @@ namespace PgOutput2Json
         {
             try
             {
-                tokenSource?.Cancel();
+                if (tokenSource != null && !tokenSource.IsCancellationRequested)
+                {
+                    tokenSource.Cancel();
+                }
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    logger?.LogError(ex, "Error cancelling a token source");
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public static async Task TryCancelAsync(this CancellationTokenSource? tokenSource, ILogger? logger)
+        {
+            try
+            {
+                if (tokenSource != null && !tokenSource.IsCancellationRequested)
+                {
+                    await tokenSource.CancelAsync().ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {

--- a/src/PgOutput2Json/JsonWriter.cs
+++ b/src/PgOutput2Json/JsonWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,14 @@ namespace PgOutput2Json
         public StringBuilder TableName { get; internal set; } = new(256); 
         public StringBuilder KeyKolValue { get; internal set; } = new(256);
         public StringBuilder PartitionKolValue { get; internal set; } = new(256);
+
+        public void Clear()
+        {
+            Json.Clear(); 
+            TableName.Clear(); 
+            KeyKolValue.Clear(); 
+            PartitionKolValue.Clear();
+        }
     }
 
     public class JsonWriter
@@ -121,10 +130,51 @@ namespace PgOutput2Json
                                       token)
                     .ConfigureAwait(false);
             }
+            else if (message is LogicalDecodingMessage logicalDecodingMsg)
+            {
+                await WriteLogicalDecodingMessageAsync(logicalDecodingMsg, commitTimeStamp, virtualLsn, token)
+                    .ConfigureAwait(false);
+            }
 
             _result.WalSeqNo = message != null ? (ulong)message.WalEnd : 0;
 
             return _result;
+        }
+
+        private async Task WriteLogicalDecodingMessageAsync(LogicalDecodingMessage logicalDecodingMsg, DateTime commitTimeStamp, NpgsqlLogSequenceNumber virtualLsn, CancellationToken token)
+        {
+            _result.Clear();
+            JsonBuilder.Append("{\"c\":\"M\""); // change type: message
+            JsonBuilder.Append(",\"w\":");
+            JsonBuilder.Append((ulong)virtualLsn);
+
+            if (_jsonOptions.WriteTimestamps)
+            {
+                if (_jsonOptions.TimestampFormat == TimestampFormat.UnixTimeMilliseconds)
+                {
+                    JsonBuilder.Append(",\"cts\":");
+                    JsonBuilder.Append(new DateTimeOffset(commitTimeStamp).ToUnixTimeMilliseconds());
+                    JsonBuilder.Append(",\"mts\":");
+                    JsonBuilder.Append(new DateTimeOffset(logicalDecodingMsg.ServerClock).ToUnixTimeMilliseconds());
+                }
+                else
+                {
+                    JsonBuilder.Append(",\"cts\":");
+                    JsonBuilder.Append(commitTimeStamp.Ticks);
+                    JsonBuilder.Append(",\"mts\":");
+                    JsonBuilder.Append(logicalDecodingMsg.ServerClock.Ticks);
+                }
+            }
+
+            JsonBuilder.Append(",\"p\":");
+            JsonUtils.WriteText(JsonBuilder, logicalDecodingMsg.Prefix);
+
+            using var reader = new StreamReader(logicalDecodingMsg.Data);
+            string data = await reader.ReadToEndAsync(token).ConfigureAwait(false);
+
+            JsonBuilder.Append(",\"d\":");
+            JsonUtils.WriteText(JsonBuilder, data);
+            JsonBuilder.Append('}');
         }
 
         private async Task WriteTupleAsync(TransactionalMessage msg,

--- a/src/PgOutput2Json/PgOutput2JsonBuilder.cs
+++ b/src/PgOutput2Json/PgOutput2JsonBuilder.cs
@@ -121,6 +121,12 @@ namespace PgOutput2Json
             return this;
         }
 
+        public PgOutput2JsonBuilder WithIdleWalMessageInterval(TimeSpan interval)
+        {
+            _listenerOptions.IdleWalMessageInterval = interval;
+            return this;
+        }
+
         public IPgOutput2Json Build()
         {
             if (_listenerOptions.DataSourceBuilder.ConnectionString == string.Empty)

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
+using Npgsql;
 using Npgsql.Replication;
 using Npgsql.Replication.PgOutput;
 using Npgsql.Replication.PgOutput.Messages;
@@ -23,9 +24,18 @@ namespace PgOutput2Json
             public int UnconfirmedCount { get; set; }
             public NpgsqlLogSequenceNumber LastWalEnd { get; set; }
 
+            public Timer? IdleConfirmTimer { get; set; }
+            public Timer? IdleWalMessageTimer { get; set; }
+
             public async ValueTask DisposeAsync()
             {
                 LinkedCts.TryDispose(_logger);
+
+                await IdleConfirmTimer.TryDisposeAsync(_logger).ConfigureAwait(false);
+                IdleConfirmTimer = null;
+
+                await IdleWalMessageTimer.TryDisposeAsync(_logger).ConfigureAwait(false);
+                IdleWalMessageTimer = null;
 
                 await MessagePublisher.TryDisposeAsync(_logger).ConfigureAwait(false);
                 MessagePublisher = null;
@@ -63,7 +73,7 @@ namespace PgOutput2Json
             // TODO: see if DataSourceBuilder can be used
             if (_loggerFactory != null)
             {
-                Npgsql.NpgsqlLoggingConfiguration.InitializeLogging(_loggerFactory);
+                NpgsqlLoggingConfiguration.InitializeLogging(_loggerFactory);
             }
         }
 
@@ -73,10 +83,15 @@ namespace PgOutput2Json
             {
                 var state = new ConnectionState(cancellationToken, _logger);
 
-                Timer idleConfirmTimer;
                 using (ExecutionContext.SuppressFlow())
                 {
-                    idleConfirmTimer = new Timer(IdleTimerCallback, state, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                    state.IdleConfirmTimer = new Timer(IdleTimerCallback, state, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                    if (_options.IdleWalMessageInterval > TimeSpan.Zero
+                        && _options.IdleWalMessageInterval != Timeout.InfiniteTimeSpan)
+                    {
+                        state.IdleWalMessageTimer = new Timer(IdleWalMessageTimerCallback, state, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                    }
                 }
 
                 try
@@ -120,9 +135,12 @@ namespace PgOutput2Json
                     // this counts messages with the same WalStart
                     var messageNo = 0UL;
 
-                    var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
+                    var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1, messages: true);
 
                     var replicationMessage = new ReplicationMessage { HasRelationChanged = true, CommitTimeStamp = DateTime.UtcNow, };
+
+                    // start the keeplive timer just before starting the replication
+                    state.IdleWalMessageTimer?.Change(_options.IdleWalMessageInterval, Timeout.InfiniteTimeSpan);
 
                     // linkedCts.Token is used only in this foreach loop,
                     // since lock ensures idle confirm cannot happen at the same time
@@ -133,7 +151,8 @@ namespace PgOutput2Json
                         {
                             //_logger?.LogWarning("{Type} {WalStart}/{MesssageNo}", message.GetType().Name, message.WalStart, messageNo);
 
-                            idleConfirmTimer.Change(_options.BatchWaitTime, Timeout.InfiniteTimeSpan);
+                            state.IdleConfirmTimer?.Change(_options.BatchWaitTime, Timeout.InfiniteTimeSpan);
+                            state.IdleWalMessageTimer?.Change(_options.IdleWalMessageInterval, Timeout.InfiniteTimeSpan);
 
                             if (message is RelationMessage rel)
                             {
@@ -202,7 +221,7 @@ namespace PgOutput2Json
                                 continue;
                             }
 
-                            idleConfirmTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                            state.IdleConfirmTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
                             await ConfirmAsync(state).ConfigureAwait(false);
 
@@ -236,8 +255,6 @@ namespace PgOutput2Json
                     // we don't use cancellation token here, as we want to dispose always
                     using (await _lock.LockAsync(CancellationToken.None).ConfigureAwait(false))
                     {
-                        idleConfirmTimer.TryDispose(_logger);
-
                         await state.TryDisposeAsync(_logger).ConfigureAwait(false);
                     }
                 }
@@ -310,6 +327,41 @@ namespace PgOutput2Json
                 {
                     _logger.SafeLogError(exx, "Error cancelling link token source");
                 }
+            }
+        }
+#pragma warning restore VSTHRD100 // Avoid async void methods
+
+#pragma warning disable VSTHRD100 // Avoid async void methods
+        private async void IdleWalMessageTimerCallback(object? state)
+        {
+            var cs = (ConnectionState)state!;
+
+            try
+            {
+                if (cs.CancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                await using var conn = new NpgsqlConnection(_options.ConnectionString);
+                await conn.OpenAsync(cs.CancellationToken).ConfigureAwait(false);
+
+                await using var cmd = new NpgsqlCommand(
+                    "SELECT pg_logical_emit_message(false, 'keepalive', '')", conn);
+
+                await cmd.ExecuteNonQueryAsync(cs.CancellationToken).ConfigureAwait(false);
+
+                _logger.SafeLogDebug("Emitted idle WAL keepalive message");
+
+                cs.IdleWalMessageTimer?.Change(_options.IdleWalMessageInterval, Timeout.InfiniteTimeSpan);
+            }
+            catch (OperationCanceledException) when (cs.CancellationToken.IsCancellationRequested)
+            {
+                // stopping - nothing to do
+            }
+            catch (Exception ex)
+            {
+                _logger.SafeLogError(ex, "Error emitting idle WAL message");
             }
         }
 #pragma warning restore VSTHRD100 // Avoid async void methods

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -12,6 +12,29 @@ namespace PgOutput2Json
 {
     internal sealed class ReplicationListener
     {
+        private class ConnectionState(CancellationToken cancellationToken, ILogger? logger) : IAsyncDisposable
+        {
+            private readonly ILogger? _logger = logger;
+
+            public LogicalReplicationConnection? Connection { get; set; }
+            public IMessagePublisher? MessagePublisher { get; set; }
+            public CancellationTokenSource LinkedCts { get; } = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            public CancellationToken CancellationToken { get; } = cancellationToken;
+            public int UnconfirmedCount { get; set; }
+            public NpgsqlLogSequenceNumber LastWalEnd { get; set; }
+
+            public async ValueTask DisposeAsync()
+            {
+                LinkedCts.TryDispose(_logger);
+
+                await MessagePublisher.TryDisposeAsync(_logger).ConfigureAwait(false);
+                MessagePublisher = null;
+
+                await Connection.TryDisposeAsync(_logger).ConfigureAwait(false);
+                Connection = null;
+            }
+        }
+
         private readonly ILoggerFactory? _loggerFactory;
         private readonly ILogger<ReplicationListener>? _logger;
 
@@ -23,17 +46,6 @@ namespace PgOutput2Json
         private readonly IMessagePublisherFactory _messagePublisherFactory;
 
         private readonly AsyncLock _lock = new();
-
-        private Timer? _idleConfirmTimer;
-
-        private LogicalReplicationConnection? _connection;
-        private IMessagePublisher? _messagePublisher;
-
-        private CancellationToken _cancellationToken = CancellationToken.None;
-        private CancellationTokenSource? _linkedCts;
-
-        private int _unconfirmedCount;
-        private NpgsqlLogSequenceNumber _lastWalEnd;
 
         public ReplicationListener(IMessagePublisherFactory messagePublisherFactory,
                                    ReplicationListenerOptions options,
@@ -57,20 +69,24 @@ namespace PgOutput2Json
 
         public async Task ListenForChangesAsync(CancellationToken cancellationToken)
         {
-            if (_connection != null) throw new Exception("Already listening");
-
-            _cancellationToken = cancellationToken;
-
             while (!cancellationToken.IsCancellationRequested)
             {
+                var state = new ConnectionState(cancellationToken, _logger);
+
+                Timer idleConfirmTimer;
+                using (ExecutionContext.SuppressFlow())
+                {
+                    idleConfirmTimer = new Timer(IdleTimerCallback, state, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                }
+
                 try
                 {
-                    _connection = new LogicalReplicationConnection(_options.ConnectionString)
+                    state.Connection = new LogicalReplicationConnection(_options.ConnectionString)
                     {
                         WalReceiverStatusInterval = Timeout.InfiniteTimeSpan // we are sending status manually
                     };
 
-                    await _connection.Open(cancellationToken)
+                    await state.Connection.Open(cancellationToken)
                         .ConfigureAwait(false);
 
                     _logger.SafeLogInfo("Connected to PostgreSQL");
@@ -87,49 +103,37 @@ namespace PgOutput2Json
                     }
                     else
                     {
-                        slot = await _connection.CreatePgOutputReplicationSlot(slotName, true, cancellationToken: cancellationToken)
+                        slot = await state.Connection.CreatePgOutputReplicationSlot(slotName, true, cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
 
                     // start data export after creating the temporary replication slot
                     await DataExporter.MaybeExportDataAsync(_messagePublisherFactory, _options, _jsonOptions, slotName, _loggerFactory, cancellationToken).ConfigureAwait(false);
 
-                    _messagePublisher = _messagePublisherFactory.CreateMessagePublisher(_options, slotName, _loggerFactory);
+                    state.MessagePublisher = _messagePublisherFactory.CreateMessagePublisher(_options, slotName, _loggerFactory);
 
                     // virtual lsn is start lsn + msg number
-                    var lastVirtualLsn = new NpgsqlLogSequenceNumber(await _messagePublisher.GetLastPublishedWalSeqAsync(cancellationToken).ConfigureAwait(false));
+                    var lastVirtualLsn = new NpgsqlLogSequenceNumber(await state.MessagePublisher.GetLastPublishedWalSeqAsync(cancellationToken).ConfigureAwait(false));
 
                     var lastWalStart = new NpgsqlLogSequenceNumber(0);
-
-                    _lastWalEnd = new NpgsqlLogSequenceNumber(0);
 
                     // this counts messages with the same WalStart
                     var messageNo = 0UL;
 
                     var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
 
-                    // we will use cts to cancel the loop, if the idle confirm fails
-                    _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-                    _unconfirmedCount = 0;
-
-                    using (ExecutionContext.SuppressFlow())
-                    {
-                        _idleConfirmTimer = new Timer(IdleTimerCallback);
-                    }
-
                     var replicationMessage = new ReplicationMessage { HasRelationChanged = true, CommitTimeStamp = DateTime.UtcNow, };
 
                     // linkedCts.Token is used only in this foreach loop,
                     // since lock ensures idle confirm cannot happen at the same time
-                    await foreach (var message in _connection.StartReplication(slot, replicationOptions, _linkedCts.Token)
+                    await foreach (var message in state.Connection.StartReplication(slot, replicationOptions, state.LinkedCts.Token)
                         .ConfigureAwait(false))
                     {
                         using (await _lock.LockAsync(cancellationToken).ConfigureAwait(false))
                         {
                             //_logger?.LogWarning("{Type} {WalStart}/{MesssageNo}", message.GetType().Name, message.WalStart, messageNo);
 
-                            _idleConfirmTimer.Change(_options.BatchWaitTime, Timeout.InfiniteTimeSpan);
+                            idleConfirmTimer.Change(_options.BatchWaitTime, Timeout.InfiniteTimeSpan);
 
                             if (message is RelationMessage rel)
                             {
@@ -150,7 +154,7 @@ namespace PgOutput2Json
                                 // DO NOT REMOVE THIS
                                 // This is checked multiple times, we must confirm this WalEnd too,
                                 // since the whole transaction will repeat otherwise.
-                                _lastWalEnd = message.WalEnd;
+                                state.LastWalEnd = message.WalEnd;
                                 continue;
                             }
 
@@ -185,24 +189,22 @@ namespace PgOutput2Json
 
                             replicationMessage.HasRelationChanged = false;
 
-                            await _messagePublisher.PublishAsync(jsonMessage, cancellationToken)
+                            await state.MessagePublisher.PublishAsync(jsonMessage, cancellationToken)
                                 .ConfigureAwait(false);
 
                             // set the lastWalEnd to be sent in status update only after the message was published
-                            _lastWalEnd = message.WalEnd;
+                            state.LastWalEnd = message.WalEnd;
 
                             MetricsHelper.IncrementPublishCounter();
 
-                            if (++_unconfirmedCount < _options.BatchSize)
+                            if (++state.UnconfirmedCount < _options.BatchSize)
                             {
                                 continue;
                             }
 
-                            _idleConfirmTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                            idleConfirmTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-                            await ConfirmAsync(_connection, _messagePublisher, _unconfirmedCount, _lastWalEnd, cancellationToken).ConfigureAwait(false);
-
-                            _unconfirmedCount = 0;
+                            await ConfirmAsync(state).ConfigureAwait(false);
 
                             _logger.SafeLogDebug("Confirmed PostgreSQL");
                         }
@@ -213,7 +215,7 @@ namespace PgOutput2Json
                     _logger.SafeLogWarn("Stopping ReplicationListener - cancellation requested");
                     break;
                 }
-                catch (OperationCanceledException) when (_linkedCts != null && _linkedCts.IsCancellationRequested)
+                catch (OperationCanceledException) when (state.LinkedCts.IsCancellationRequested)
                 {
                     // cancelled because idle confirm failed, nothing to do - error has been logged already
                 }
@@ -234,17 +236,9 @@ namespace PgOutput2Json
                     // we don't use cancellation token here, as we want to dispose always
                     using (await _lock.LockAsync(CancellationToken.None).ConfigureAwait(false))
                     {
-                        _idleConfirmTimer.TryDispose(_logger);
-                        _idleConfirmTimer = null;
+                        idleConfirmTimer.TryDispose(_logger);
 
-                        _linkedCts.TryDispose(_logger);
-                        _linkedCts = null;
-
-                        await _messagePublisher.TryDisposeAsync(_logger).ConfigureAwait(false);
-                        _messagePublisher = null;
-
-                        await _connection.TryDisposeAsync(_logger).ConfigureAwait(false);
-                        _connection = null;
+                        await state.TryDisposeAsync(_logger).ConfigureAwait(false);
                     }
                 }
 
@@ -255,22 +249,20 @@ namespace PgOutput2Json
             _logger.SafeLogInfo("Disconnected from PostgreSQL");
         }
 
-        private static async Task ConfirmAsync(LogicalReplicationConnection connection,
-                                               IMessagePublisher messagePublisher,
-                                               int unconfirmedCount,
-                                               NpgsqlLogSequenceNumber lastWalEnd,
-                                               CancellationToken cancellationToken)
+        private static async Task ConfirmAsync(ConnectionState cs)
         {
-            if (unconfirmedCount > 0)
+            if (cs.UnconfirmedCount > 0 && cs.MessagePublisher != null)
             {
-                await messagePublisher.ConfirmAsync(cancellationToken).ConfigureAwait(false);
+                await cs.MessagePublisher.ConfirmAsync(cs.CancellationToken).ConfigureAwait(false);
             }
 
-            if ((ulong)lastWalEnd > 0)
-            {
-                connection.SetReplicationStatus(lastWalEnd);
+            cs.UnconfirmedCount = 0;
 
-                await connection.SendStatusUpdate(cancellationToken)
+            if ((ulong)cs.LastWalEnd > 0 && cs.Connection != null)
+            {
+                cs.Connection.SetReplicationStatus(cs.LastWalEnd);
+
+                await cs.Connection.SendStatusUpdate(cs.CancellationToken)
                     .ConfigureAwait(false);
             }
         }
@@ -278,26 +270,26 @@ namespace PgOutput2Json
 #pragma warning disable VSTHRD100 // Avoid async void methods
         private async void IdleTimerCallback(object? state)
         {
+            var cs = (ConnectionState)state!;
+
             try
             {
-                if (_cancellationToken.IsCancellationRequested)
+                if (cs.CancellationToken.IsCancellationRequested)
                 {
                     return;
                 }
 
-                using (await _lock.LockAsync(_cancellationToken).ConfigureAwait(false))
+                using (await _lock.LockAsync(cs.CancellationToken).ConfigureAwait(false))
                 {
-                    if (_connection != null && _messagePublisher != null)
+                    if (cs.Connection != null && cs.MessagePublisher != null)
                     {
-                        await ConfirmAsync(_connection, _messagePublisher, _unconfirmedCount, _lastWalEnd, _cancellationToken).ConfigureAwait(false);
-
-                        _unconfirmedCount = 0;
+                        await ConfirmAsync(cs).ConfigureAwait(false);
                     }
 
                     _logger.SafeLogDebug("Idle Confirmed PostgreSQL");
                 }
             }
-            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException) when (cs.CancellationToken.IsCancellationRequested)
             {
                 // stopping - nothing to do
             }
@@ -308,13 +300,10 @@ namespace PgOutput2Json
                     MetricsHelper.IncrementErrorCounter();
                     _logger.SafeLogError(ex, "Error confirming published messages. Waiting for 10 seconds...");
 
-                    using (await _lock.LockAsync(_cancellationToken).ConfigureAwait(false))
+                    using (await _lock.LockAsync(cs.CancellationToken).ConfigureAwait(false))
                     {
-                        if (_linkedCts != null)
-                        {
-                            // if force confirm fails, stop the replication loop, and dispose the publisher
-                            await _linkedCts.CancelAsync().ConfigureAwait(false);
-                        }
+                        // if force confirm fails, stop the replication loop, and dispose the publisher
+                        await cs.LinkedCts.CancelAsync().ConfigureAwait(false);
                     }
                 }
                 catch (Exception exx)

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -27,8 +27,13 @@ namespace PgOutput2Json
             public Timer? IdleConfirmTimer { get; set; }
             public Timer? IdleWalMessageTimer { get; set; }
 
+            public bool IsDisposed { get; private set; }
+
             public async ValueTask DisposeAsync()
             {
+                IsDisposed = true;
+
+                await LinkedCts.TryCancelAsync(_logger).ConfigureAwait(false);
                 LinkedCts.TryDispose(_logger);
 
                 await IdleConfirmTimer.TryDisposeAsync(_logger).ConfigureAwait(false);
@@ -240,7 +245,7 @@ namespace PgOutput2Json
                 }
                 catch (Exception ex)
                 {
-                    if (ex.Message.StartsWith("55006:"))
+                    if (ex is PostgresException pgEx && pgEx.SqlState == "55006")
                     {
                         _logger.SafeLogWarn("Slot taken - waiting for 10 seconds...");
                     }
@@ -298,12 +303,12 @@ namespace PgOutput2Json
 
                 using (await _lock.LockAsync(cs.CancellationToken).ConfigureAwait(false))
                 {
-                    if (cs.Connection != null && cs.MessagePublisher != null)
+                    // check for disposal inside the lock
+                    if (!cs.IsDisposed && cs.Connection != null && cs.MessagePublisher != null)
                     {
                         await ConfirmAsync(cs).ConfigureAwait(false);
+                        _logger.SafeLogDebug("Idle Confirmed PostgreSQL");
                     }
-
-                    _logger.SafeLogDebug("Idle Confirmed PostgreSQL");
                 }
             }
             catch (OperationCanceledException) when (cs.CancellationToken.IsCancellationRequested)
@@ -319,8 +324,11 @@ namespace PgOutput2Json
 
                     using (await _lock.LockAsync(cs.CancellationToken).ConfigureAwait(false))
                     {
-                        // if force confirm fails, stop the replication loop, and dispose the publisher
-                        await cs.LinkedCts.CancelAsync().ConfigureAwait(false);
+                        if (!cs.IsDisposed)
+                        {
+                            // if force confirm fails, stop the replication loop, and dispose the publisher
+                            await cs.LinkedCts.TryCancelAsync(_logger).ConfigureAwait(false);
+                        }
                     }
                 }
                 catch (Exception exx)
@@ -353,7 +361,14 @@ namespace PgOutput2Json
 
                 _logger.SafeLogDebug("Emitted idle WAL keepalive message");
 
-                cs.IdleWalMessageTimer?.Change(_options.IdleWalMessageInterval, Timeout.InfiniteTimeSpan);
+                using (await _lock.LockAsync(cs.CancellationToken).ConfigureAwait(false))
+                {
+                    // checking for disposal inside the lock
+                    if (!cs.IsDisposed && cs.IdleWalMessageTimer != null)
+                    {
+                        cs.IdleWalMessageTimer.Change(_options.IdleWalMessageInterval, Timeout.InfiniteTimeSpan);
+                    }
+                }
             }
             catch (OperationCanceledException) when (cs.CancellationToken.IsCancellationRequested)
             {

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -12,12 +12,6 @@ namespace PgOutput2Json
 {
     internal sealed class ReplicationListener
     {
-        private class WalAwaiter
-        {
-            public TaskCompletionSource Source { get; set; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            public NpgsqlLogSequenceNumber ExpectedWalEnd { get; set; }
-        }
-
         private readonly ILoggerFactory? _loggerFactory;
         private readonly ILogger<ReplicationListener>? _logger;
 
@@ -28,7 +22,18 @@ namespace PgOutput2Json
 
         private readonly IMessagePublisherFactory _messagePublisherFactory;
 
-        private readonly AsyncLock _lock = new AsyncLock();
+        private readonly AsyncLock _lock = new();
+
+        private Timer? _idleConfirmTimer;
+
+        private LogicalReplicationConnection? _connection;
+        private IMessagePublisher? _messagePublisher;
+
+        private CancellationToken _cancellationToken = CancellationToken.None;
+        private CancellationTokenSource? _linkedCts;
+
+        private int _unconfirmedCount;
+        private NpgsqlLogSequenceNumber _lastWalEnd;
 
         public ReplicationListener(IMessagePublisherFactory messagePublisherFactory,
                                    ReplicationListenerOptions options,
@@ -52,213 +57,154 @@ namespace PgOutput2Json
 
         public async Task ListenForChangesAsync(CancellationToken cancellationToken)
         {
+            if (_connection != null) throw new Exception("Already listening");
+
+            _cancellationToken = cancellationToken;
+
             while (!cancellationToken.IsCancellationRequested)
             {
-                IMessagePublisher? messagePublisher = null;
-                CancellationTokenSource? linkedCts = null;
-                Timer? idleConfirmTimer = null;
-
                 try
                 {
-                    var connection = new LogicalReplicationConnection(_options.ConnectionString);
-
-                    await using (connection.ConfigureAwait(false))
+                    _connection = new LogicalReplicationConnection(_options.ConnectionString)
                     {
-                        connection.WalReceiverStatusInterval = Timeout.InfiniteTimeSpan; // we are sending status manually
+                        WalReceiverStatusInterval = Timeout.InfiniteTimeSpan // we are sending status manually
+                    };
 
-                        await connection.Open(cancellationToken)
+                    await _connection.Open(cancellationToken)
+                        .ConfigureAwait(false);
+
+                    _logger.SafeLogInfo("Connected to PostgreSQL");
+
+                    var slotName = string.IsNullOrWhiteSpace(_options.ReplicationSlotName)
+                            ? $"pg2j_{Guid.NewGuid().ToString().Replace("-", "")}"
+                            : _options.ReplicationSlotName;
+
+                    PgOutputReplicationSlot slot;
+
+                    if (!_options.UseTemporarySlot)
+                    {
+                        slot = new PgOutputReplicationSlot(_options.ReplicationSlotName);
+                    }
+                    else
+                    {
+                        slot = await _connection.CreatePgOutputReplicationSlot(slotName, true, cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
+                    }
 
-                        _logger.SafeLogInfo("Connected to PostgreSQL");
+                    // start data export after creating the temporary replication slot
+                    await DataExporter.MaybeExportDataAsync(_messagePublisherFactory, _options, _jsonOptions, slotName, _loggerFactory, cancellationToken).ConfigureAwait(false);
 
-                        var slotName = string.IsNullOrWhiteSpace(_options.ReplicationSlotName)
-                                ? $"pg2j_{Guid.NewGuid().ToString().Replace("-", "")}"
-                                : _options.ReplicationSlotName;
+                    _messagePublisher = _messagePublisherFactory.CreateMessagePublisher(_options, slotName, _loggerFactory);
 
-                        PgOutputReplicationSlot slot;
+                    // virtual lsn is start lsn + msg number
+                    var lastVirtualLsn = new NpgsqlLogSequenceNumber(await _messagePublisher.GetLastPublishedWalSeqAsync(cancellationToken).ConfigureAwait(false));
 
-                        if (!_options.UseTemporarySlot)
+                    var lastWalStart = new NpgsqlLogSequenceNumber(0);
+
+                    _lastWalEnd = new NpgsqlLogSequenceNumber(0);
+
+                    // this counts messages with the same WalStart
+                    var messageNo = 0UL;
+
+                    var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
+
+                    // we will use cts to cancel the loop, if the idle confirm fails
+                    _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                    _unconfirmedCount = 0;
+
+                    using (ExecutionContext.SuppressFlow())
+                    {
+                        _idleConfirmTimer = new Timer(IdleTimerCallback);
+                    }
+
+                    var replicationMessage = new ReplicationMessage { HasRelationChanged = true, CommitTimeStamp = DateTime.UtcNow, };
+
+                    // linkedCts.Token is used only in this foreach loop,
+                    // since lock ensures idle confirm cannot happen at the same time
+                    await foreach (var message in _connection.StartReplication(slot, replicationOptions, _linkedCts.Token)
+                        .ConfigureAwait(false))
+                    {
+                        using (await _lock.LockAsync(cancellationToken).ConfigureAwait(false))
                         {
-                            slot = new PgOutputReplicationSlot(_options.ReplicationSlotName);
-                        }
-                        else
-                        {
-                            slot = await connection.CreatePgOutputReplicationSlot(slotName, true, cancellationToken: cancellationToken)
+                            //_logger?.LogWarning("{Type} {WalStart}/{MesssageNo}", message.GetType().Name, message.WalStart, messageNo);
+
+                            _idleConfirmTimer.Change(_options.BatchWaitTime, Timeout.InfiniteTimeSpan);
+
+                            if (message is RelationMessage rel)
+                            {
+                                replicationMessage.HasRelationChanged = true;
+
+                                // Relation Message has WalEnd=0/0
+                                continue;
+                            }
+
+                            if (message is BeginMessage beginMsg)
+                            {
+                                replicationMessage.CommitTimeStamp = beginMsg.TransactionCommitTimestamp;
+                                continue;
+                            }
+
+                            if (message is CommitMessage commitMsg)
+                            {
+                                // DO NOT REMOVE THIS
+                                // This is checked multiple times, we must confirm this WalEnd too,
+                                // since the whole transaction will repeat otherwise.
+                                _lastWalEnd = message.WalEnd;
+                                continue;
+                            }
+
+                            if (lastWalStart != message.WalStart)
+                            {
+                                lastWalStart = message.WalStart;
+                                messageNo = 0UL;
+                            }
+                            else
+                            {
+                                messageNo++;
+                            }
+
+                            var virtualLsn = lastWalStart + messageNo;
+
+                            if (virtualLsn <= lastVirtualLsn && _options.UseDeduplication)
+                            {
+                                // already processed
+                                _logger?.LogWarning("Skipping already published message: " +
+                                    "WalStart = {WalStart}, " +
+                                    "MessageNo = {MesageNo}, " +
+                                    "LastVirtualLsn = {LastVirtualLsn}", lastWalStart, messageNo, lastVirtualLsn);
+                                continue;
+                            }
+
+                            lastVirtualLsn = virtualLsn;
+
+                            replicationMessage.Message = message;
+
+                            var jsonMessage = await _writer.WriteMessageAsync(replicationMessage, lastVirtualLsn, cancellationToken)
                                 .ConfigureAwait(false);
-                        }
 
-                        // start data export after creating the temporary replication slot
-                        await DataExporter.MaybeExportDataAsync(_messagePublisherFactory, _options, _jsonOptions, slotName, _loggerFactory, cancellationToken).ConfigureAwait(false);
+                            replicationMessage.HasRelationChanged = false;
 
-                        messagePublisher = _messagePublisherFactory.CreateMessagePublisher(_options, slotName, _loggerFactory);
+                            await _messagePublisher.PublishAsync(jsonMessage, cancellationToken)
+                                .ConfigureAwait(false);
 
-                        // virtual lsn is start lsn + msg number
-                        var lastVirtualLsn = new NpgsqlLogSequenceNumber(await messagePublisher.GetLastPublishedWalSeqAsync(cancellationToken).ConfigureAwait(false));
+                            // set the lastWalEnd to be sent in status update only after the message was published
+                            _lastWalEnd = message.WalEnd;
 
-                        var lastWalStart = new NpgsqlLogSequenceNumber(0);
-                        
-                        var lastWalEnd = new NpgsqlLogSequenceNumber(0);
+                            MetricsHelper.IncrementPublishCounter();
 
-                        // this counts messages with the same WalStart
-                        var messageNo = 0UL;
-
-                        var replicationOptions = new PgOutputReplicationOptions(_options.PublicationNames, PgOutputProtocolVersion.V1);
-
-                        // we will use cts to cancel the loop, if the idle confirm fails
-                        linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
-                        var unconfirmedCount = 0;
-
-                        async Task TimerCallbackAsync()
-                        {
-                            try
+                            if (++_unconfirmedCount < _options.BatchSize)
                             {
-                                if (cancellationToken.IsCancellationRequested)
-                                {
-                                    return;
-                                }
-
-                                using (await _lock.LockAsync(cancellationToken).ConfigureAwait(false))
-                                {
-                                    if (unconfirmedCount > 0 && messagePublisher != null)
-                                    {
-                                        await messagePublisher.ConfirmAsync(cancellationToken)
-                                            .ConfigureAwait(false);
-                                    }
-
-                                    unconfirmedCount = 0;
-
-                                    await SendStatusUpdateAsync(connection, lastWalEnd, cancellationToken)
-                                        .ConfigureAwait(false);
-
-                                    _logger.SafeLogDebug("Idle Confirmed PostgreSQL");
-                                }
+                                continue;
                             }
-                            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                            {
-                                // stopping - nothing to do
-                            }
-                            catch (Exception ex)
-                            {
-                                MetricsHelper.IncrementErrorCounter();
-                                _logger.SafeLogError(ex, "Error confirming published messages. Waiting for 10 seconds...");
 
-                                try
-                                {
-                                    using (await _lock.LockAsync(cancellationToken).ConfigureAwait(false))
-                                    {
-                                        if (linkedCts != null)
-                                        {
-                                            // if force confirm fails, stop the replication loop, and dispose the publisher
-                                            await linkedCts.CancelAsync().ConfigureAwait(false);
-                                        }
-                                    }
-                                }
-                                catch (Exception exx)
-                                {
-                                    MetricsHelper.IncrementErrorCounter();
-                                    _logger.SafeLogError(exx, "Error cancelling link token source");
-                                }
-                            }
-                        }
+                            _idleConfirmTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-                        idleConfirmTimer = new Timer(_ =>
-                        {
-                            _ = TimerCallbackAsync(); // fire and forget
-                        });
+                            await ConfirmAsync(_connection, _messagePublisher, _unconfirmedCount, _lastWalEnd, cancellationToken).ConfigureAwait(false);
 
-                        var replicationMessage = new ReplicationMessage { HasRelationChanged = true, CommitTimeStamp = DateTime.UtcNow, };
+                            _unconfirmedCount = 0;
 
-                        // linkedCts.Token is used only in this foreach loop,
-                        // since lock ensures idle confirm cannot happen at the same time
-                        await foreach (var message in connection.StartReplication(slot, replicationOptions, linkedCts.Token)
-                            .ConfigureAwait(false))
-                        {
-                            using (await _lock.LockAsync(cancellationToken).ConfigureAwait(false))
-                            {
-                                 //_logger?.LogWarning("{Type} {WalStart}/{MesssageNo}", message.GetType().Name, message.WalStart, messageNo);
-
-                                idleConfirmTimer.Change(_options.BatchWaitTime, Timeout.InfiniteTimeSpan);
-
-                                if (message is RelationMessage rel)
-                                {
-                                    replicationMessage.HasRelationChanged = true;
-
-                                    // Relation Message has WalEnd=0/0
-                                    continue;
-                                }
-                               
-                                if (message is BeginMessage beginMsg)
-                                {
-                                    replicationMessage.CommitTimeStamp = beginMsg.TransactionCommitTimestamp;
-                                    continue;
-                                }
-
-                                if (message is CommitMessage commitMsg)
-                                {
-                                    // DO NOT REMOVE THIS
-                                    // This is checked multiple times, we must confirm this WalEnd too,
-                                    // since the whole transaction will repeat otherwise.
-                                    lastWalEnd = message.WalEnd;
-                                    continue;
-                                }
-
-                                if (lastWalStart != message.WalStart)
-                                {
-                                    lastWalStart = message.WalStart;
-                                    messageNo = 0UL;
-                                }
-                                else
-                                {
-                                    messageNo++;
-                                }
-
-                                var virtualLsn = lastWalStart + messageNo;
-
-                                if (virtualLsn <= lastVirtualLsn && _options.UseDeduplication)
-                                {
-                                    // already processed
-                                    _logger?.LogWarning("Skipping already published message: " +
-                                        "WalStart = {WalStart}, " +
-                                        "MessageNo = {MesageNo}, " +
-                                        "LastVirtualLsn = {LastVirtualLsn}", lastWalStart, messageNo, lastVirtualLsn);
-                                    continue;
-                                }
-
-                                lastVirtualLsn = virtualLsn;
-
-                                replicationMessage.Message = message;
-
-                                var jsonMessage = await _writer.WriteMessageAsync(replicationMessage, lastVirtualLsn, cancellationToken)
-                                    .ConfigureAwait(false);
-
-                                replicationMessage.HasRelationChanged = false;
-
-                                await messagePublisher.PublishAsync(jsonMessage, cancellationToken)
-                                    .ConfigureAwait(false);
-
-                                // set the lastWalEnd to be sent in status update only after the message was published
-                                lastWalEnd = message.WalEnd;
-
-                                MetricsHelper.IncrementPublishCounter();
-
-                                if (++unconfirmedCount < _options.BatchSize)
-                                {
-                                    continue;
-                                }
-
-                                idleConfirmTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-
-                                await messagePublisher.ConfirmAsync(cancellationToken)
-                                    .ConfigureAwait(false);
-
-                                unconfirmedCount = 0;
-
-                                await SendStatusUpdateAsync(connection, lastWalEnd, cancellationToken)
-                                        .ConfigureAwait(false);
-
-                                _logger.SafeLogDebug("Confirmed PostgreSQL");
-                            }
+                            _logger.SafeLogDebug("Confirmed PostgreSQL");
                         }
                     }
                 }
@@ -267,7 +213,7 @@ namespace PgOutput2Json
                     _logger.SafeLogWarn("Stopping ReplicationListener - cancellation requested");
                     break;
                 }
-                catch (OperationCanceledException) when (linkedCts != null && linkedCts.IsCancellationRequested)
+                catch (OperationCanceledException) when (_linkedCts != null && _linkedCts.IsCancellationRequested)
                 {
                     // cancelled because idle confirm failed, nothing to do - error has been logged already
                 }
@@ -285,17 +231,20 @@ namespace PgOutput2Json
                 }
                 finally
                 {
-                    await idleConfirmTimer.TryDisposeAsync(_logger).ConfigureAwait(false);
-                    idleConfirmTimer = null;
-
                     // we don't use cancellation token here, as we want to dispose always
                     using (await _lock.LockAsync(CancellationToken.None).ConfigureAwait(false))
                     {
-                        await messagePublisher.TryDisposeAsync(_logger).ConfigureAwait(false);
-                        messagePublisher = null;
+                        _idleConfirmTimer.TryDispose(_logger);
+                        _idleConfirmTimer = null;
 
-                        linkedCts.TryDispose(_logger);
-                        linkedCts = null;
+                        _linkedCts.TryDispose(_logger);
+                        _linkedCts = null;
+
+                        await _messagePublisher.TryDisposeAsync(_logger).ConfigureAwait(false);
+                        _messagePublisher = null;
+
+                        await _connection.TryDisposeAsync(_logger).ConfigureAwait(false);
+                        _connection = null;
                     }
                 }
 
@@ -306,8 +255,17 @@ namespace PgOutput2Json
             _logger.SafeLogInfo("Disconnected from PostgreSQL");
         }
 
-        private static async Task SendStatusUpdateAsync(LogicalReplicationConnection connection, NpgsqlLogSequenceNumber lastWalEnd, CancellationToken cancellationToken)
+        private static async Task ConfirmAsync(LogicalReplicationConnection connection,
+                                               IMessagePublisher messagePublisher,
+                                               int unconfirmedCount,
+                                               NpgsqlLogSequenceNumber lastWalEnd,
+                                               CancellationToken cancellationToken)
         {
+            if (unconfirmedCount > 0)
+            {
+                await messagePublisher.ConfirmAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             if ((ulong)lastWalEnd > 0)
             {
                 connection.SetReplicationStatus(lastWalEnd);
@@ -316,6 +274,56 @@ namespace PgOutput2Json
                     .ConfigureAwait(false);
             }
         }
+
+#pragma warning disable VSTHRD100 // Avoid async void methods
+        private async void IdleTimerCallback(object? state)
+        {
+            try
+            {
+                if (_cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                using (await _lock.LockAsync(_cancellationToken).ConfigureAwait(false))
+                {
+                    if (_connection != null && _messagePublisher != null)
+                    {
+                        await ConfirmAsync(_connection, _messagePublisher, _unconfirmedCount, _lastWalEnd, _cancellationToken).ConfigureAwait(false);
+
+                        _unconfirmedCount = 0;
+                    }
+
+                    _logger.SafeLogDebug("Idle Confirmed PostgreSQL");
+                }
+            }
+            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            {
+                // stopping - nothing to do
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    MetricsHelper.IncrementErrorCounter();
+                    _logger.SafeLogError(ex, "Error confirming published messages. Waiting for 10 seconds...");
+
+                    using (await _lock.LockAsync(_cancellationToken).ConfigureAwait(false))
+                    {
+                        if (_linkedCts != null)
+                        {
+                            // if force confirm fails, stop the replication loop, and dispose the publisher
+                            await _linkedCts.CancelAsync().ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (Exception exx)
+                {
+                    _logger.SafeLogError(exx, "Error cancelling link token source");
+                }
+            }
+        }
+#pragma warning restore VSTHRD100 // Avoid async void methods
 
         private async Task DelayAsync(int time, CancellationToken cancellationToken)
         {

--- a/src/PgOutput2Json/ReplicationListener.cs
+++ b/src/PgOutput2Json/ReplicationListener.cs
@@ -208,13 +208,16 @@ namespace PgOutput2Json
 
                             replicationMessage.Message = message;
 
-                            var jsonMessage = await _writer.WriteMessageAsync(replicationMessage, lastVirtualLsn, cancellationToken)
-                                .ConfigureAwait(false);
+                            if (message is not LogicalDecodingMessage logicalDecodingMsg || logicalDecodingMsg.Prefix != "pg2j_keepalive")
+                            {
+                                var jsonMessage = await _writer.WriteMessageAsync(replicationMessage, lastVirtualLsn, cancellationToken)
+                                    .ConfigureAwait(false);
 
-                            replicationMessage.HasRelationChanged = false;
+                                replicationMessage.HasRelationChanged = false;
 
-                            await state.MessagePublisher.PublishAsync(jsonMessage, cancellationToken)
-                                .ConfigureAwait(false);
+                                await state.MessagePublisher.PublishAsync(jsonMessage, cancellationToken)
+                                    .ConfigureAwait(false);
+                            }
 
                             // set the lastWalEnd to be sent in status update only after the message was published
                             state.LastWalEnd = message.WalEnd;
@@ -355,11 +358,11 @@ namespace PgOutput2Json
                 await conn.OpenAsync(cs.CancellationToken).ConfigureAwait(false);
 
                 await using var cmd = new NpgsqlCommand(
-                    "SELECT pg_logical_emit_message(false, 'keepalive', '')", conn);
+                    "SELECT pg_logical_emit_message(false, 'pg2j_keepalive', '')", conn);
 
                 await cmd.ExecuteNonQueryAsync(cs.CancellationToken).ConfigureAwait(false);
 
-                _logger.SafeLogDebug("Emitted idle WAL keepalive message");
+                _logger.SafeLogDebug("Emitted idle WAL pg2j_keepalive message");
 
                 using (await _lock.LockAsync(cs.CancellationToken).ConfigureAwait(false))
                 {

--- a/src/PgOutput2Json/ReplicationListenerOptions.cs
+++ b/src/PgOutput2Json/ReplicationListenerOptions.cs
@@ -51,5 +51,13 @@ namespace PgOutput2Json
         public int CopyDataBatchSize { get; internal set; }
 
         public int MaxParallelCopyJobs { get; internal set; } = 1;
+
+        /// <summary>
+        /// Interval at which pg_logical_emit_message is called to prevent restart_lsn from lagging
+        /// when replicated tables are idle but other tables generate WAL.
+        /// Set to <see cref="TimeSpan.Zero"/> or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to disable.
+        /// Default is 10 seconds.
+        /// </summary>
+        public TimeSpan IdleWalMessageInterval { get; internal set; } = TimeSpan.FromSeconds(10);
     }
 }


### PR DESCRIPTION
If there are no changes in the tables belonging to a publication, WAL is being retained indefinitely.  This pull requests enables periodic calling **pg_logical_emit_message(false, 'pg2j_keepalive', '')** to introduce artificial traffic.